### PR TITLE
feat: persist PWA prompt dismissal

### DIFF
--- a/src/components/layout/PWAPrompt.tsx
+++ b/src/components/layout/PWAPrompt.tsx
@@ -12,7 +12,14 @@ export function PWAPrompt() {
   const { toast } = useToast()
 
   useEffect(() => {
-    // Show prompt after 30 seconds if app is installable and not dismissed
+    const storedDismissed = localStorage.getItem('pwa-prompt-dismissed')
+    if (storedDismissed === 'true') {
+      setDismissed(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    // Show prompt after 30 seconds if app is installable and not previously dismissed
     const timer = setTimeout(() => {
       if (isInstallable && !isInstalled && !dismissed) {
         setShowPrompt(true)
@@ -60,7 +67,7 @@ export function PWAPrompt() {
     localStorage.setItem('pwa-prompt-dismissed', 'true')
   }
 
-  // Don't show if already installed or user dismissed
+  // Don't show if already installed, not installable, or user previously dismissed
   if (isInstalled || !isInstallable || !showPrompt) {
     return null
   }


### PR DESCRIPTION
## Summary
- check `pwa-prompt-dismissed` flag in `localStorage` on mount
- document and enforce persistent dismissal of the PWA install prompt

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c26d4d0832dbd0d216d8f60efb3