### PR TITLE
Prevent adding roles when checkbox indeterminate

### DIFF
--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -17,8 +17,9 @@ export default function Security() {
 
   const handleRoleToggle = (role: typeof roleOptions[number], checked: boolean | string) => {
     if (!user) return;
+    if (checked === 'indeterminate') return;
     const next = new Set(user.roles);
-    if (checked) next.add(role as any); else next.delete(role as any);
+    if (checked === true) next.add(role as any); else next.delete(role as any);
     setRoles(Array.from(next) as any);
     addEvent({
       actor: { id: user.id, name: user.name, email: user.email },


### PR DESCRIPTION
## Summary
- prevent role assignment when checkbox is indeterminate
- check explicitly for `true` when adding roles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68ab8c260250832db975ecb64b6ac23a