### PR TITLE
fix: avoid duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure `useToast` listener effect runs only once to prevent duplicate registrations

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a3edf38832d9447941d8754b270