### PR TITLE
docs: clarify nvm install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changes made via Lovable will be committed automatically to this repo.
 
 If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
 
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+The only requirement is having Node.js & npm installed — [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
 Follow these steps:
 


### PR DESCRIPTION
## Summary
- replace hyphen with em dash in README's nvm installation link to avoid line break confusion

## Testing
- `codespell`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a3ebd98832db80cbc655e5c2d3e