### PR TITLE
chore: ignore bun lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+bun.lockb
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- ignore Bun's lockfile to avoid multiple package manager lockfiles

## Testing
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba01be978832dabcd322128dea5ca