### PR TITLE
chore: audit application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## chore: remove Lov​able integration
 - remove Lov​able-specific dependencies and configuration
 - clean up Lov​able mentions from documentation
+
+## chore: audit application and record broken features
+- add audit report and scripts
+- pin `date-fns` to 3.x to satisfy `react-day-picker`

--- a/docs/app-audit.md
+++ b/docs/app-audit.md
@@ -1,0 +1,74 @@
+# Application Audit
+
+## Executive Summary
+- Clean install completed with `date-fns` pinned to `3.6.0` to satisfy `react-day-picker`.
+- `npm run dev`, `npm run build`, `npm run preview`, and `npm test` all terminate with a `Bus error` before serving or building.
+- Lint (`npm run lint`) and TypeScript check (`npx tsc --noEmit`) complete without issues.
+- Playwright is not installed; `scripts/audit/crawl.js` fails with `ERR_MODULE_NOT_FOUND`.
+
+## Feature Map
+| Route | Feature | Key UI Elements | Status |
+|-------|---------|-----------------|--------|
+| `/` | Dashboard with KPI cards, charts, meeting and proposal summaries | "New Proposal" button, charts, cards | Broken – dev server fails to start |
+| `/documents` | Document library with filters, table, preview/version dialogs | Filter form, document table, preview modal | Not tested – app fails to run |
+| `/meetings` | Meetings list and quick actions | Upcoming/recent meeting cards, action buttons | Not tested – app fails to run |
+| `/proposals` | Proposal CRUD and bulk actions | Search/filter inputs, proposal table, dropdown actions | Not tested – app fails to run |
+| `/knowledge` | Knowledge base articles and search | Category cards, search bar | Not tested – app fails to run |
+| `/workflows` | Workflow templates overview | Workflow cards, create button | Not tested – app fails to run |
+| `/analytics` | Reporting dashboards | Charts, filters | Not tested – app fails to run |
+| `/collaboration` | Team collaboration tools | Chat placeholders, invite button | Not tested – app fails to run |
+| `/security` | Security & audit logs | Settings table, log list | Not tested – app fails to run |
+| `/settings` | Application settings and themes | Theme selector, profile form | Not tested – app fails to run |
+| `*` | Not found page | Return home link | Not tested – app fails to run |
+
+## Broken Items
+### 1. Dev server crashes immediately
+- **Route**: All
+- **Steps**: `npm run dev`
+- **Expected**: Vite starts on `http://localhost:8080`
+- **Actual**: Process exits with `Bus error` before starting
+- **Logs**:
+  ```
+  npm run dev
+  Bus error
+  ```
+- **Minimal fix**: Replace `@vitejs/plugin-react-swc` with `@vitejs/plugin-react` in `vite.config.ts` or run on hardware supporting SWC required instructions.
+
+### 2. Build step fails
+- **Steps**: `npm run build`
+- **Expected**: Compiled production assets
+- **Actual**: `Bus error`
+- **Minimal fix**: Same as above.
+
+### 3. Preview step fails
+- **Steps**: `npm run preview`
+- **Expected**: Preview server after build
+- **Actual**: `Bus error`
+- **Minimal fix**: Same as above.
+
+### 4. Tests cannot run
+- **Steps**: `npm test`
+- **Expected**: Vitest test suite executes
+- **Actual**: `Bus error`
+- **Minimal fix**: Same as above.
+
+### 5. Audit crawler cannot run
+- **Steps**: `node scripts/audit/crawl.js`
+- **Expected**: Crawls running app
+- **Actual**: `ERR_MODULE_NOT_FOUND: Cannot find package 'playwright'`
+- **Minimal fix**: Install Playwright (`npm install -D playwright`) once dev server issue resolved.
+
+## Build, Lint, and Type Check Status
+- `npm run dev` – **failed** (`Bus error`)
+- `npm run build` – **failed** (`Bus error`)
+- `npm run preview` – **failed** (`Bus error`)
+- `npm run lint` – **passed**
+- `npx tsc --noEmit` – **passed**
+- `npm test` – **failed** (`Bus error`)
+
+## Peer Dependency Resolution
+- Resolved `react-day-picker` and `date-fns` peer conflict by pinning `date-fns` to version `3.6.0` in `package.json`.
+
+## Service Worker / Port Sanity
+- `index.html` registers `/sw.js`; `public/sw.js` exists.
+- Vite dev server configured for port `8080`; no hardcoded ports found elsewhere.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^4.1.0",
+    "date-fns": "3.6.0",
     "dexie": "^4.2.0",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,10 @@
+# Audit Scripts
+
+These scripts attempt to crawl the running application and capture console errors.
+
+## Usage
+1. Ensure the dev server is running on http://localhost:8080.
+2. Install Playwright: `npm install -D playwright` (if not already installed).
+3. Run the crawler: `node crawl.js`.
+
+The current audit run could not execute because the dev server exits with a `Bus error` before it can start.

--- a/scripts/audit/crawl.js
+++ b/scripts/audit/crawl.js
@@ -1,0 +1,15 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  try {
+    await page.goto('http://localhost:8080/', { waitUntil: 'domcontentloaded', timeout: 5000 });
+    const buttons = await page.$$eval('button, [role="button"]', els => els.map(el => el.textContent?.trim()));
+    console.log('Buttons on page:', buttons);
+  } catch (err) {
+    console.error('Navigation failed:', err);
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- document audit findings and broken features
- add placeholder audit scripts
- pin `date-fns` to 3.x to resolve peer dependency conflict

## Testing
- `npm run dev` *(fails: Bus error)*
- `npm run build` *(fails: Bus error)*
- `npm run preview` *(fails: Bus error)*
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Bus error)*
- `node scripts/audit/crawl.js` *(fails: Cannot find package 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68aba1ccd460832d9807b0bfd5baaf9b