### PR TITLE
Only register service worker in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script type="module" src="/src/main.tsx"></script>
     <script>
       // Register service worker for PWA functionality
-      if ('serviceWorker' in navigator) {
+      if (import.meta.env.PROD && 'serviceWorker' in navigator) {
         window.addEventListener('load', () => {
           navigator.serviceWorker.register('/sw.js')
             .then((registration) => {


### PR DESCRIPTION
## Summary
- Guard service worker registration with `import.meta.env.PROD` to avoid SW during development.

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba8229634832d9a343441f9723784