### PR TITLE
refactor: replace CRA service worker with Vite version

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,108 +1,68 @@
-const CACHE_NAME = 'cft-manager-v1'
-const urlsToCache = [
-  '/',
-  '/static/js/bundle.js',
-  '/static/css/main.css',
-  '/manifest.json'
-]
+const CACHE_NAME = 'synapse-cache-v1'
+const PRECACHE_URLS = ['/', '/manifest.json', '/icon-192x192.png']
 
-// Install event - cache resources
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => {
-        return cache.addAll(urlsToCache)
-      })
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          fetch(url)
+            .then((response) => {
+              if (response.ok) {
+                return cache.put(url, response)
+              }
+            })
+            .catch(() => {})
+        )
+      )
+    )
   )
 })
 
-// Fetch event - serve from cache when offline
-self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Return cached version or fetch from network
-        return response || fetch(event.request)
-      })
-      .catch(() => {
-        // If both cache and network fail, show offline page
-        if (event.request.destination === 'document') {
-          return caches.match('/offline.html')
-        }
-      })
-  )
-})
-
-// Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName)
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key)
           }
         })
       )
-    })
+    )
   )
 })
 
-// Background sync for form submissions
-self.addEventListener('sync', (event) => {
-  if (event.tag === 'background-sync') {
-    event.waitUntil(handleBackgroundSync())
-  }
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  )
 })
 
-async function handleBackgroundSync() {
-  // Handle offline form submissions
-  try {
-    const cache = await caches.open(CACHE_NAME)
-    // Process any queued requests
-    console.log('Background sync completed')
-  } catch (error) {
-    console.error('Background sync failed:', error)
-  }
+if ('SyncManager' in self) {
+  self.addEventListener('sync', (event) => {
+    if (event.tag === 'background-sync') {
+      event.waitUntil(handleBackgroundSync())
+    }
+  })
 }
 
-// Push notifications
-self.addEventListener('push', (event) => {
-  const options = {
-    body: event.data ? event.data.text() : 'New update available',
-    icon: '/icon-192x192.png',
-    badge: '/icon-192x192.png',
-    vibrate: [100, 50, 100],
-    data: {
-      dateOfArrival: Date.now(),
-      primaryKey: 1
-    },
-    actions: [
-      {
-        action: 'explore',
-        title: 'View Details',
-        icon: '/icon-192x192.png'
-      },
-      {
-        action: 'close',
-        title: 'Close',
-        icon: '/icon-192x192.png'
-      }
-    ]
-  }
+async function handleBackgroundSync() {
+  console.log('Background sync triggered')
+}
 
-  event.waitUntil(
-    self.registration.showNotification('CFT Manager', options)
-  )
-})
+if ('PushManager' in self && self.registration && self.registration.showNotification) {
+  self.addEventListener('push', (event) => {
+    const options = {
+      body: event.data ? event.data.text() : '',
+      icon: '/icon-192x192.png'
+    }
+    event.waitUntil(self.registration.showNotification('Synapse', options))
+  })
 
-// Notification click handling
-self.addEventListener('notificationclick', (event) => {
-  event.notification.close()
-
-  if (event.action === 'explore') {
-    event.waitUntil(
-      clients.openWindow('/')
-    )
-  }
-})
+  self.addEventListener('notificationclick', (event) => {
+    event.notification.close()
+    event.waitUntil(self.clients.openWindow('/'))
+  })
+}


### PR DESCRIPTION
## Summary
- replace legacy CRA service worker with minimal Vite-compatible implementation
- cache root, manifest and icon when present, remove offline fallback
- guard sync and push handlers with feature checks

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abac0ab22c832d9857edc7d8d27446