### PR TITLE
fix: prevent Playwright tests from running in Vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'tests/**'],
+  },
+});


### PR DESCRIPTION
## Summary
- exclude the Playwright `tests/` folder from Vitest's test search to avoid `Playwright Test did not expect test() to be called here`

## Testing
- `npx vitest run --passWithNoTests`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68abad7a4494832d965002bf7655a700