### PR TITLE
chore: replace CRA service worker with Vite-compatible version

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,46 +1,18 @@
-const CACHE_NAME = 'cft-manager-v1'
-const urlsToCache = [
-  '/',
-  '/static/js/bundle.js',
-  '/static/css/main.css',
-  '/manifest.json'
-]
+const CACHE_NAME = 'synapse-cache-v1'
+const OPTIONAL_CACHE_URLS = ['/', '/manifest.json', '/icon-192x192.png']
 
-// Install event - cache resources
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => {
-        return cache.addAll(urlsToCache)
-      })
-  )
-})
-
-// Fetch event - serve from cache when offline
-self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Return cached version or fetch from network
-        return response || fetch(event.request)
-      })
-      .catch(() => {
-        // If both cache and network fail, show offline page
-        if (event.request.destination === 'document') {
-          return caches.match('/offline.html')
-        }
-      })
-  )
-})
-
-// Activate event - clean up old caches
-self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName)
+    caches.open(CACHE_NAME).then(async (cache) => {
+      await Promise.all(
+        OPTIONAL_CACHE_URLS.map(async (url) => {
+          try {
+            const response = await fetch(url)
+            if (response.ok) {
+              await cache.put(url, response)
+            }
+          } catch {
+            // Ignore missing files
           }
         })
       )
@@ -48,61 +20,61 @@ self.addEventListener('activate', (event) => {
   )
 })
 
-// Background sync for form submissions
-self.addEventListener('sync', (event) => {
-  if (event.tag === 'background-sync') {
-    event.waitUntil(handleBackgroundSync())
-  }
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((key) => key !== CACHE_NAME && caches.delete(key)))
+    )
+  )
 })
 
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  )
+})
+
+if ('sync' in self.registration) {
+  self.addEventListener('sync', (event) => {
+    if (event.tag === 'background-sync') {
+      event.waitUntil(handleBackgroundSync())
+    }
+  })
+}
+
 async function handleBackgroundSync() {
-  // Handle offline form submissions
   try {
     const cache = await caches.open(CACHE_NAME)
-    // Process any queued requests
     console.log('Background sync completed')
   } catch (error) {
     console.error('Background sync failed:', error)
   }
 }
 
-// Push notifications
-self.addEventListener('push', (event) => {
-  const options = {
-    body: event.data ? event.data.text() : 'New update available',
-    icon: '/icon-192x192.png',
-    badge: '/icon-192x192.png',
-    vibrate: [100, 50, 100],
-    data: {
-      dateOfArrival: Date.now(),
-      primaryKey: 1
-    },
-    actions: [
-      {
-        action: 'explore',
-        title: 'View Details',
-        icon: '/icon-192x192.png'
+if ('PushManager' in self) {
+  self.addEventListener('push', (event) => {
+    const options = {
+      body: event.data ? event.data.text() : 'New update available',
+      icon: '/icon-192x192.png',
+      badge: '/icon-192x192.png',
+      vibrate: [100, 50, 100],
+      data: {
+        dateOfArrival: Date.now(),
+        primaryKey: 1,
       },
-      {
-        action: 'close',
-        title: 'Close',
-        icon: '/icon-192x192.png'
-      }
-    ]
-  }
+      actions: [
+        { action: 'explore', title: 'View Details', icon: '/icon-192x192.png' },
+        { action: 'close', title: 'Close', icon: '/icon-192x192.png' },
+      ],
+    }
 
-  event.waitUntil(
-    self.registration.showNotification('CFT Manager', options)
-  )
-})
+    event.waitUntil(self.registration.showNotification('Synapse', options))
+  })
 
-// Notification click handling
-self.addEventListener('notificationclick', (event) => {
-  event.notification.close()
-
-  if (event.action === 'explore') {
-    event.waitUntil(
-      clients.openWindow('/')
-    )
-  }
-})
+  self.addEventListener('notificationclick', (event) => {
+    event.notification.close()
+    if (event.action === 'explore') {
+      event.waitUntil(clients.openWindow('/'))
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- simplify service worker for Vite setup
- conditionally cache root, manifest, and icon assets
- guard sync and push events with feature checks

## Testing
- `npm test -- --run` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abaf2b34a0832d93c2ee860d4f1f9f