### PR TITLE
docs: add dev debug runtime diagnostics

### DIFF
--- a/docs/runtime-diagnostics.md
+++ b/docs/runtime-diagnostics.md
@@ -1,0 +1,14 @@
+# Runtime Diagnostics
+
+## dev:debug on current environment
+
+```
+$ npm run dev:debug
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+npm error Missing script: "dev:debug"
+npm error
+npm error To see a list of scripts, run:
+npm error   npm run
+npm error A complete log of this run can be found in: /root/.npm/_logs/2025-08-25T01_01_26_984Z-debug-0.log
+```
+


### PR DESCRIPTION
## Summary
- add `dev:debug` runtime diagnostics to docs

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68abb5ca8590832d987b85ed28055811