### PR TITLE
chore: separate e2e tests from unit tests

### DIFF
--- a/docs/testing-setup.md
+++ b/docs/testing-setup.md
@@ -1,0 +1,64 @@
+# Testing setup
+
+## Playwright files detected
+- tests/example.spec.ts
+
+## Vitest run
+
+```
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> vite_react_shadcn_ts@0.0.0 test
+> vitest run --passWithNoTests
+
+
+ RUN  v3.2.4 /workspace/Synapse
+
+No test files found, exiting with code 0
+
+include: src/**/*.{test,spec}.{ts,tsx}, tests/unit/**/*.spec.{ts,tsx}
+exclude:  tests/e2e/**, **/*.e2e.*, node_modules/**, dist/**
+```
+
+## Playwright run
+
+```
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> vite_react_shadcn_ts@0.0.0 test:e2e
+> playwright test
+
+
+Running 1 test using 1 worker
+
+  ✘  1 tests/e2e/example.e2e.ts:3:1 › example (6ms)
+
+
+  1) tests/e2e/example.e2e.ts:3:1 › example ────────────────────────────────────────────────────────
+
+    Error: browserType.launch: 
+    ╔══════════════════════════════════════════════════════╗
+    ║ Host system is missing dependencies to run browsers. ║
+    ║ Please install them with the following command:      ║
+    ║                                                      ║
+    ║     npx playwright install-deps                      ║
+    ║                                                      ║
+    ║ Alternatively, use apt:                              ║
+    ║     apt-get install libatk1.0-0t64\                  ║
+    ║         libatk-bridge2.0-0t64\                       ║
+    ║         libatspi2.0-0t64\                            ║
+    ║         libxcomposite1\                              ║
+    ║         libxdamage1\                                 ║
+    ║         libxfixes3\                                  ║
+    ║         libxrandr2\                                  ║
+    ║         libgbm1\                                     ║
+    ║         libxkbcommon0\                               ║
+    ║         libasound2t64                                ║
+    ║                                                      ║
+    ║ <3 Playwright Team                                   ║
+    ╚══════════════════════════════════════════════════════╝
+
+  1 failed
+    tests/e2e/example.e2e.ts:3:1 › example ─────────────────────────────────────────────────────────
+```
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -80,6 +81,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^15.15.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@playwright/test';
-
 export default defineConfig({
-  testDir: './tests',
+  testDir: 'tests/e2e',
+  testMatch: /.*\.e2e\.ts$/,
 });
+

--- a/tests/e2e/example.e2e.ts
+++ b/tests/e2e/example.e2e.ts
@@ -4,3 +4,4 @@ test('example', async ({ page }) => {
   await page.goto('https://example.com');
   await expect(page).toHaveTitle(/Example/);
 });
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/unit/**/*.spec.{ts,tsx}'],
+    exclude: ['tests/e2e/**', '**/*.e2e.*', 'node_modules/**', 'dist/**'],
+    environment: 'jsdom',
+    globals: true,
+    passWithNoTests: true,
+  },
+});
+


### PR DESCRIPTION
## Summary
- document Playwright test files and recent test runs
- configure Vitest and Playwright to keep e2e tests separate
- update test scripts and add jsdom for Vitest

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68abbd820068832d8696d8b56fc4040d