### PR TITLE
test: add routes smoke test

### DIFF
--- a/docs/testing-setup.md
+++ b/docs/testing-setup.md
@@ -32,3 +32,51 @@ Running 1 test using 1 worker
   1 failed
     tests/example.spec.ts:3:1 › example ────────────────────────────────────────────────────────────
 ```
+
+## Routes smoke run
+
+```
+> vite_react_shadcn_ts@0.0.0 test:e2e
+> playwright test
+
+
+Running 10 tests using 1 worker
+
+  ✘   1 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to / (21ms)
+  ✘   2 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /documents (9ms)
+  ✘   3 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /meetings (7ms)
+  ✘   4 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /proposals (8ms)
+  ✘   5 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /knowledge (8ms)
+  ✘   6 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /workflows (9ms)
+  ✘   7 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /analytics (8ms)
+  ✘   8 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /collaboration (7ms)
+  ✘   9 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /security (8ms)
+  ✘  10 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /settings (7ms)
+
+
+  1) tests/e2e/routes.e2e.ts:12:5 › routes › navigate to / ─────────────────────────────────────────
+
+    Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell
+    ╔═════════════════════════════════════════════════════════════════════════╗
+    ║ Looks like Playwright Test or Playwright was just installed or updated. ║
+    ║ Please run the following command to download new browsers:              ║
+    ║                                                                         ║
+    ║     npx playwright install                                              ║
+    ║                                                                         ║
+    ║ <3 Playwright Team                                                      ║
+    ╚═════════════════════════════════════════════════════════════════════════╝
+
+  ... 8 more failures ...
+
+  10 failed
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to / ──────────────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /documents ─────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /meetings ──────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /proposals ─────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /knowledge ─────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /workflows ─────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /analytics ─────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /collaboration ─────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /security ──────────────────────────────────
+    tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /settings ──────────────────────────────────
+```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,4 +2,10 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  webServer: {
+    command: 'npm run dev -- --port 5173',
+    port: 5173,
+    reuseExistingServer: true,
+  },
 });

--- a/tests/e2e/routes.e2e.ts
+++ b/tests/e2e/routes.e2e.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const routes = [
+  '/', '/documents', '/meetings', '/proposals', '/knowledge',
+  '/workflows', '/analytics', '/collaboration', '/security', '/settings'
+];
+
+const base = process.env.PW_BASE_URL ?? 'http://localhost:5173';
+
+test.describe('routes', () => {
+  for (const path of routes) {
+    test(`navigate to ${path}`, async ({ page }) => {
+      await page.goto(base + path);
+      await expect(page.locator('#root')).toBeVisible();
+    });
+  }
+});

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('example', async ({ page }) => {
-  await page.goto('https://example.com');
-  await expect(page).toHaveTitle(/Example/);
-});


### PR DESCRIPTION
## Summary
- add Playwright smoke test covering top-level routes
- configure Playwright for `.e2e.ts` tests and local dev server
- document routes smoke run

## Testing
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac82120db4832dbec28acc6157be68