### PR TITLE
Add test IDs for primary action buttons

### DIFF
--- a/docs/testing-setup.md
+++ b/docs/testing-setup.md
@@ -80,3 +80,16 @@ Running 10 tests using 1 worker
     tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /security ──────────────────────────────────
     tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /settings ──────────────────────────────────
 ```
+
+## data-testid mapping
+
+| Route | Visible label/icon | data-testid | File:Line |
+|-------|-------------------|-------------|-----------|
+| /proposals | New Proposal | new-proposal-btn | src/pages/Proposals.tsx:226 |
+| /proposals | Delete | delete-proposal-btn | src/pages/Proposals.tsx:406 |
+| /documents | Upload Document | upload-agenda-btn | src/pages/Documents.tsx:266 |
+| /documents | Eye icon | preview-doc-btn | src/pages/Documents.tsx:428 |
+| /meetings | New Meeting | create-meeting-btn | src/pages/Meetings.tsx:148 |
+| /meetings | Start | start-meeting-btn | src/pages/Meetings.tsx:228 |
+| /settings | Save Changes | save-settings-btn | src/pages/Settings.tsx:190 |
+

--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -259,11 +259,12 @@ export default function Documents() {
               </Button>
             </>
           )}
-          <Button 
-            onClick={handleUploadClick}
-            disabled={isUploading}
-            aria-label="Upload new document"
-          >
+            <Button
+              onClick={handleUploadClick}
+              disabled={isUploading}
+              aria-label="Upload new document"
+              data-testid="upload-agenda-btn"
+            >
             {isUploading ? (
               <>
                 <Upload className="mr-2 h-4 w-4 animate-spin" />
@@ -419,12 +420,13 @@ export default function Documents() {
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end space-x-1">
-                          <Button 
-                            variant="ghost" 
-                            size="sm"
-                            onClick={() => setPreviewDocument(doc)}
-                            aria-label={`Preview ${doc.name}`}
-                          >
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setPreviewDocument(doc)}
+                              aria-label={`Preview ${doc.name}`}
+                              data-testid="preview-doc-btn"
+                            >
                             <Eye className="h-4 w-4" />
                           </Button>
                           <Button 

--- a/src/pages/Meetings.tsx
+++ b/src/pages/Meetings.tsx
@@ -141,11 +141,12 @@ export default function Meetings() {
             <PlayCircle className="mr-2 h-4 w-4" />
             Meeting Mode
           </Button>
-          <Button 
-            onClick={handleCreateMeeting}
-            disabled={isCreating}
-            aria-label="Create new meeting"
-          >
+            <Button
+              onClick={handleCreateMeeting}
+              disabled={isCreating}
+              aria-label="Create new meeting"
+              data-testid="create-meeting-btn"
+            >
             {isCreating ? (
               <>
                 <Plus className="mr-2 h-4 w-4 animate-spin" />
@@ -219,12 +220,13 @@ export default function Meetings() {
                         <Edit className="mr-1 h-3 w-3" />
                         Edit
                       </Button>
-                      <Button 
-                        size="sm"
-                        onClick={() => handleJoinMeeting(meeting.id, meeting.title)}
-                        disabled={isJoining}
-                        aria-label={`Join ${meeting.title}`}
-                      >
+                        <Button
+                          size="sm"
+                          onClick={() => handleJoinMeeting(meeting.id, meeting.title)}
+                          disabled={isJoining}
+                          aria-label={`Join ${meeting.title}`}
+                          data-testid="start-meeting-btn"
+                        >
                         {isJoining ? (
                           "Joining..."
                         ) : (

--- a/src/pages/Proposals.tsx
+++ b/src/pages/Proposals.tsx
@@ -219,10 +219,11 @@ export default function Proposals() {
               </>
             )}
           </Button>
-          <Button 
+          <Button
             onClick={handleCreateProposal}
             disabled={isCreating}
             aria-label="Create new proposal"
+            data-testid="new-proposal-btn"
           >
             {isCreating ? (
               <>
@@ -399,9 +400,10 @@ export default function Proposals() {
                           Reject
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem 
+                        <DropdownMenuItem
                           onClick={() => handleDeleteProposal(proposal.id, proposal.title)}
                           className="text-destructive"
+                          data-testid="delete-proposal-btn"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />
                           Delete

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -187,7 +187,7 @@ export default function Settings() {
               <Input id="role" value={userProfile.role} disabled />
             </div>
           </div>
-          <Button onClick={handleProfileSave} disabled={isLoadingProfile}>
+          <Button onClick={handleProfileSave} disabled={isLoadingProfile} data-testid="save-settings-btn">
             {isLoadingProfile ? "Saving..." : "Save Changes"}
           </Button>
         </CardContent>


### PR DESCRIPTION
## Summary
- add `data-testid` attributes for key action buttons on proposals, documents, meetings, and settings pages
- document test IDs in testing-setup guide

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68ac93fe0124832d98a635a5383b0551