### PR TITLE
Add static button audit

### DIFF
--- a/artifacts/buttons-static.json
+++ b/artifacts/buttons-static.json
@@ -1,0 +1,265 @@
+[
+  {
+    "file": "src/pages/Documents.tsx",
+    "line": 502,
+    "rule": "a",
+    "component": "Documents",
+    "ariaLabel": "Select files to upload",
+    "text": "",
+    "snippet": "<Button disabled={isUploading} aria-label=\"Select files to upload\" >",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/pages/Proposals.tsx",
+    "line": 369,
+    "rule": "a",
+    "component": "Proposals",
+    "ariaLabel": "Proposal actions",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" aria-label=\"Proposal actions\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/analytics/AnalyticsDashboard.tsx",
+    "line": 81,
+    "rule": "a",
+    "component": "AnalyticsDashboard",
+    "text": "",
+    "snippet": "<Button variant=\"outline\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/analytics/CustomDashboard.tsx",
+    "line": 110,
+    "rule": "a",
+    "component": "CustomDashboard",
+    "text": "",
+    "snippet": "<Button>",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/analytics/ReportBuilder.tsx",
+    "line": 238,
+    "rule": "a",
+    "component": "ReportBuilder",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/analytics/ReportBuilder.tsx",
+    "line": 242,
+    "rule": "a",
+    "component": "ReportBuilder",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/ActivityFeed.tsx",
+    "line": 129,
+    "rule": "a",
+    "component": "ActivityFeed",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/ActivityFeed.tsx",
+    "line": 133,
+    "rule": "a",
+    "component": "ActivityFeed",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/CollaborationPresence.tsx",
+    "line": 277,
+    "rule": "a",
+    "component": "CollaborationPresence",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/CommentSystem.tsx",
+    "line": 94,
+    "rule": "a",
+    "component": "CommentItem",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-6 w-6 p-0\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/CommentSystem.tsx",
+    "line": 183,
+    "rule": "a",
+    "component": "CommentItem",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-6 px-2\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/CommentSystem.tsx",
+    "line": 320,
+    "rule": "a",
+    "component": "CommentSystem",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/CommentSystem.tsx",
+    "line": 324,
+    "rule": "a",
+    "component": "CommentSystem",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/TeamManagement.tsx",
+    "line": 101,
+    "rule": "a",
+    "component": "TeamCard",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-8 w-8 p-0\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/collaboration/TeamManagement.tsx",
+    "line": 277,
+    "rule": "a",
+    "component": "TeamManagement",
+    "text": "",
+    "snippet": "<Button>",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/documents/DocumentFilters.tsx",
+    "line": 72,
+    "rule": "a",
+    "component": "DocumentFilters",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" className={cn( \"relative\", hasActiveFilters && \"border-primary\" )}>",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/layout/AppHeader.tsx",
+    "line": 60,
+    "rule": "a",
+    "component": "AppHeader",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" className=\"relative h-9 w-9 rounded-full\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/layout/MobileNav.tsx",
+    "line": 35,
+    "rule": "a",
+    "component": "MobileNav",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"md:hidden h-9 w-9 p-0\" >",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 83,
+    "rule": "a",
+    "component": "NotificationItem",
+    "text": "",
+    "snippet": "<Button variant=\"link\" size=\"sm\" className=\"h-auto p-0 text-xs\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 92,
+    "rule": "a",
+    "component": "NotificationItem",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-8 w-8 p-0\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 155,
+    "rule": "a",
+    "component": "NotificationCenter",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-9 w-9 p-0 relative\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 173,
+    "rule": "a",
+    "component": "NotificationCenter",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 262,
+    "rule": "a",
+    "component": "NotificationCenter",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/notifications/NotificationCenter.tsx",
+    "line": 269,
+    "rule": "a",
+    "component": "NotificationCenter",
+    "text": "",
+    "snippet": "<Button variant=\"outline\" size=\"sm\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/ui/date-range-picker.tsx",
+    "line": 35,
+    "rule": "a",
+    "component": "DatePickerWithRange",
+    "text": "",
+    "snippet": "<Button id=\"date\" variant={\"outline\"} className={cn( \"w-[300px] justify-start text-left font-normal\"",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/workflow/WorkflowCreateDialog.tsx",
+    "line": 272,
+    "rule": "a",
+    "component": "WorkflowCreateDialog",
+    "text": "",
+    "snippet": "<Button type=\"submit\" disabled={isLoading}>",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/workflow/WorkflowManager.tsx",
+    "line": 96,
+    "rule": "a",
+    "component": "WorkflowCard",
+    "text": "",
+    "snippet": "<Button variant=\"ghost\" size=\"sm\" className=\"h-8 w-8 p-0\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/workflow/WorkflowManager.tsx",
+    "line": 279,
+    "rule": "a",
+    "component": "WorkflowManager",
+    "text": "",
+    "snippet": "<Button variant=\"outline\">",
+    "reason": "missing onClick/asChild/href/to"
+  },
+  {
+    "file": "src/components/workflow/WorkflowStepDialog.tsx",
+    "line": 141,
+    "rule": "a",
+    "component": "WorkflowStepDialog",
+    "text": "",
+    "snippet": "<Button type=\"submit\" disabled={isLoading}>",
+    "reason": "missing onClick/asChild/href/to"
+  }
+]

--- a/docs/buttons-static-audit.md
+++ b/docs/buttons-static-audit.md
@@ -1,0 +1,83 @@
+# Buttons Static Audit
+
+## Findings
+
+| File | Line | Rule | Component | data-testid | aria-label | Text | Snippet |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| src/pages/Documents.tsx | 502 | a | Documents |  | Select files to upload |  | `<Button disabled={isUploading} aria-label="Select files to upload" >` |
+| src/pages/Proposals.tsx | 369 | a | Proposals |  | Proposal actions |  | `<Button variant="ghost" size="sm" aria-label="Proposal actions">` |
+| src/components/analytics/AnalyticsDashboard.tsx | 81 | a | AnalyticsDashboard |  |  |  | `<Button variant="outline">` |
+| src/components/analytics/CustomDashboard.tsx | 110 | a | CustomDashboard |  |  |  | `<Button>` |
+| src/components/analytics/ReportBuilder.tsx | 238 | a | ReportBuilder |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/analytics/ReportBuilder.tsx | 242 | a | ReportBuilder |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/ActivityFeed.tsx | 129 | a | ActivityFeed |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/ActivityFeed.tsx | 133 | a | ActivityFeed |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/CollaborationPresence.tsx | 277 | a | CollaborationPresence |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/CommentSystem.tsx | 94 | a | CommentItem |  |  |  | `<Button variant="ghost" size="sm" className="h-6 w-6 p-0">` |
+| src/components/collaboration/CommentSystem.tsx | 183 | a | CommentItem |  |  |  | `<Button variant="ghost" size="sm" className="h-6 px-2">` |
+| src/components/collaboration/CommentSystem.tsx | 320 | a | CommentSystem |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/CommentSystem.tsx | 324 | a | CommentSystem |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/collaboration/TeamManagement.tsx | 101 | a | TeamCard |  |  |  | `<Button variant="ghost" size="sm" className="h-8 w-8 p-0">` |
+| src/components/collaboration/TeamManagement.tsx | 277 | a | TeamManagement |  |  |  | `<Button>` |
+| src/components/documents/DocumentFilters.tsx | 72 | a | DocumentFilters |  |  |  | `<Button variant="outline" className={cn( "relative", hasActiveFilters && "border-primary" )}>` |
+| src/components/layout/AppHeader.tsx | 60 | a | AppHeader |  |  |  | `<Button variant="ghost" className="relative h-9 w-9 rounded-full">` |
+| src/components/layout/MobileNav.tsx | 35 | a | MobileNav |  |  |  | `<Button variant="ghost" size="sm" className="md:hidden h-9 w-9 p-0" >` |
+| src/components/notifications/NotificationCenter.tsx | 83 | a | NotificationItem |  |  |  | `<Button variant="link" size="sm" className="h-auto p-0 text-xs">` |
+| src/components/notifications/NotificationCenter.tsx | 92 | a | NotificationItem |  |  |  | `<Button variant="ghost" size="sm" className="h-8 w-8 p-0">` |
+| src/components/notifications/NotificationCenter.tsx | 155 | a | NotificationCenter |  |  |  | `<Button variant="ghost" size="sm" className="h-9 w-9 p-0 relative">` |
+| src/components/notifications/NotificationCenter.tsx | 173 | a | NotificationCenter |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/notifications/NotificationCenter.tsx | 262 | a | NotificationCenter |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/notifications/NotificationCenter.tsx | 269 | a | NotificationCenter |  |  |  | `<Button variant="outline" size="sm">` |
+| src/components/ui/date-range-picker.tsx | 35 | a | DatePickerWithRange |  |  |  | `<Button id="date" variant={"outline"} className={cn( "w-[300px] justify-start text-left font-normal"` |
+| src/components/workflow/WorkflowCreateDialog.tsx | 272 | a | WorkflowCreateDialog |  |  |  | `<Button type="submit" disabled={isLoading}>` |
+| src/components/workflow/WorkflowManager.tsx | 96 | a | WorkflowCard |  |  |  | `<Button variant="ghost" size="sm" className="h-8 w-8 p-0">` |
+| src/components/workflow/WorkflowManager.tsx | 279 | a | WorkflowManager |  |  |  | `<Button variant="outline">` |
+| src/components/workflow/WorkflowStepDialog.tsx | 141 | a | WorkflowStepDialog |  |  |  | `<Button type="submit" disabled={isLoading}>` |
+
+## Summary
+
+### Totals per rule
+- (a) <Button> without onClick/asChild/href/to: 29
+- (b) <button> without onClick and not disabled: 0
+- (c) <a role="button"> without href/to: 0
+- (d) data-testid "-btn" elements without handlers: 0
+
+### Top 10 files by count
+- src/components/notifications/NotificationCenter.tsx: 6
+- src/components/collaboration/CommentSystem.tsx: 4
+- src/components/analytics/ReportBuilder.tsx: 2
+- src/components/collaboration/ActivityFeed.tsx: 2
+- src/components/collaboration/TeamManagement.tsx: 2
+- src/components/workflow/WorkflowManager.tsx: 2
+- src/pages/Documents.tsx: 1
+- src/pages/Proposals.tsx: 1
+- src/components/analytics/AnalyticsDashboard.tsx: 1
+- src/components/analytics/CustomDashboard.tsx: 1
+
+### Suggested minimal fixes
+- Add onClick handlers or link props (href/to) for interactive buttons.
+- Convert <a role="button"> to <Link to="..."> or add href.
+- Ensure data-testid "-btn" elements are wired or removed.
+
+## Script Run Output
+
+```
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> vite_react_shadcn_ts@0.0.0 audit:buttons:static
+> ts-node --transpile-only scripts/audit/buttons-static.ts
+
+Total candidates: 29
+Rule totals: { a: 29, b: 0, c: 0, d: 0 }
+Top files:
+- src/components/notifications/NotificationCenter.tsx: 6
+- src/components/collaboration/CommentSystem.tsx: 4
+- src/components/analytics/ReportBuilder.tsx: 2
+- src/components/collaboration/ActivityFeed.tsx: 2
+- src/components/collaboration/TeamManagement.tsx: 2
+- src/components/workflow/WorkflowManager.tsx: 2
+- src/pages/Documents.tsx: 1
+- src/pages/Proposals.tsx: 1
+- src/components/analytics/AnalyticsDashboard.tsx: 1
+- src/components/analytics/CustomDashboard.tsx: 1
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,8 @@
         "globals": "^15.15.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
+        "ts-morph": "^22.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^5.4.19",
@@ -419,6 +421,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3064,6 +3090,73 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
+      "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.3",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3241,7 +3334,7 @@
       "version": "22.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3711,7 +3804,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3728,6 +3821,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -4112,6 +4218,13 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4151,6 +4264,13 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4449,6 +4569,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -5447,6 +5577,13 @@
         "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/make-event-props": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
@@ -5515,6 +5652,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -5682,6 +5835,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6895,6 +7055,68 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-morph": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
+      "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.23.0",
+        "code-block-writer": "^13.0.1"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
@@ -6918,7 +7140,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6956,7 +7178,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -7056,6 +7278,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -7418,6 +7647,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "diag:env": "node -e \"console.log(process.versions)\"",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "audit:buttons:static": "ts-node --transpile-only scripts/audit/buttons-static.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -86,6 +87,8 @@
     "globals": "^15.15.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
+    "ts-morph": "^22.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",

--- a/scripts/audit/buttons-static.ts
+++ b/scripts/audit/buttons-static.ts
@@ -1,0 +1,173 @@
+import pkg from 'ts-morph';
+import fs from 'fs';
+import path from 'path';
+
+const { Project, SyntaxKind, Node, JsxAttribute, JsxOpeningLikeElement } = pkg;
+
+const project = new Project({ tsConfigFilePath: 'tsconfig.json' });
+project.addSourceFilesAtPaths('src/**/*.{ts,tsx}');
+
+interface RecordItem {
+  file: string;
+  line: number;
+  rule: string;
+  component?: string;
+  dataTestId?: string;
+  ariaLabel?: string;
+  text?: string;
+  snippet: string;
+  reason: string;
+}
+
+const records: RecordItem[] = [];
+
+for (const sourceFile of project.getSourceFiles()) {
+  sourceFile.forEachDescendant((node) => {
+    if (Node.isJsxOpeningElement(node) || Node.isJsxSelfClosingElement(node)) {
+      analyzeElement(node as JsxOpeningLikeElement, sourceFile);
+    }
+  });
+}
+
+function analyzeElement(node: JsxOpeningLikeElement, sourceFile: any) {
+  const tagName = node.getTagNameNode().getText();
+  const hasAttr = (name: string) => node.getAttribute(name) != null;
+  const getAttr = (name: string) => node.getAttribute(name) as JsxAttribute | undefined;
+  const attrText = (attr?: JsxAttribute) => attr?.getInitializer()?.getText();
+
+  const hasOnClick = hasAttr('onClick');
+  const onClickText = attrText(getAttr('onClick'))?.replace(/\s+/g, '');
+  const isNoop = onClickText ? /^(\(\)=>\{\}|noop\(\)?$)/.test(onClickText) : false;
+
+  const hasAsChild = hasAttr('asChild');
+  const hasHref = hasAttr('href');
+  const hasTo = hasAttr('to');
+  const disabled = hasAttr('disabled');
+  const role = attrText(getAttr('role'))?.replace(/['"`]/g, '').toLowerCase();
+  const dataTestId = attrText(getAttr('data-testid'))?.replace(/['"`]/g, '');
+  const ariaLabel = attrText(getAttr('aria-label'))?.replace(/['"`]/g, '');
+
+  const parentElement = Node.isJsxSelfClosingElement(node) ? node : node.getParentIfKind(SyntaxKind.JsxElement);
+  let text = '';
+  if (parentElement && Node.isJsxElement(parentElement)) {
+    text = parentElement.getChildrenOfKind(SyntaxKind.JsxText).map(t => t.getText().trim()).filter(Boolean).join(' ');
+  }
+
+  let rule: string | undefined;
+  let reason = '';
+
+  if (tagName === 'Button') {
+    if (!hasOnClick && !hasAsChild && !hasHref && !hasTo) {
+      rule = 'a'; reason = 'missing onClick/asChild/href/to';
+    } else if (hasOnClick && isNoop) {
+      rule = 'a'; reason = 'noop onClick';
+    }
+  } else if (tagName === 'button') {
+    if (!hasOnClick && !disabled) {
+      rule = 'b'; reason = 'missing onClick';
+    } else if (hasOnClick && isNoop) {
+      rule = 'b'; reason = 'noop onClick';
+    }
+  } else if (tagName === 'a') {
+    if (role === 'button') {
+      if (!hasHref && !hasTo) {
+        rule = 'c'; reason = 'missing href/to';
+      } else if (hasOnClick && isNoop) {
+        rule = 'c'; reason = 'noop onClick';
+      }
+    }
+  }
+
+  if (!rule && dataTestId && dataTestId.endsWith('-btn')) {
+    const hasHrefOrTo = hasHref || hasTo;
+    if (!hasOnClick && !hasHrefOrTo) {
+      rule = 'd'; reason = 'missing onClick/href';
+    } else if (hasOnClick && isNoop) {
+      rule = 'd'; reason = 'noop onClick';
+    }
+  }
+
+  if (rule) {
+    const { line } = sourceFile.getLineAndColumnAtPos(node.getStart());
+    const component = getComponentName(node);
+    const snippet = node.getText().replace(/\s+/g, ' ').slice(0, 100);
+    records.push({
+      file: path.relative(process.cwd(), sourceFile.getFilePath()),
+      line,
+      rule,
+      component,
+      dataTestId,
+      ariaLabel,
+      text,
+      snippet,
+      reason
+    });
+  }
+}
+
+function getComponentName(node: Node): string | undefined {
+  let current: Node | undefined = node;
+  while (current) {
+    const parent = current.getParent();
+    if (!parent) break;
+    if (Node.isFunctionDeclaration(parent) && parent.getName()) return parent.getName();
+    if (Node.isVariableDeclaration(parent)) {
+      const init = parent.getInitializer();
+      if (init && Node.isArrowFunction(init) && parent.getName()) return parent.getName();
+    }
+    if (Node.isClassDeclaration(parent) && parent.getName()) return parent.getName();
+    current = parent;
+  }
+  return undefined;
+}
+
+fs.mkdirSync('artifacts', { recursive: true });
+fs.mkdirSync('docs', { recursive: true });
+
+fs.writeFileSync('artifacts/buttons-static.json', JSON.stringify(records, null, 2));
+
+let md = '# Buttons Static Audit\n\n## Findings\n\n';
+md += '| File | Line | Rule | Component | data-testid | aria-label | Text | Snippet |\n';
+md += '| --- | --- | --- | --- | --- | --- | --- | --- |\n';
+for (const r of records) {
+  const row = [
+    r.file,
+    r.line,
+    r.rule,
+    r.component || '',
+    r.dataTestId || '',
+    r.ariaLabel || '',
+    (r.text || '').replace(/\|/g, '\\|'),
+    '`' + r.snippet + '`'
+  ].join(' | ');
+  md += `| ${row} |\n`;
+}
+
+const totals = { a: 0, b: 0, c: 0, d: 0 } as Record<string, number>;
+const fileCount: Record<string, number> = {};
+for (const r of records) {
+  totals[r.rule]++;
+  fileCount[r.file] = (fileCount[r.file] || 0) + 1;
+}
+
+const topFiles = Object.entries(fileCount).sort((a, b) => b[1] - a[1]).slice(0, 10)
+  .map(([f, c]) => `- ${f}: ${c}`).join('\n');
+
+md += '\n## Summary\n\n### Totals per rule\n';
+md += `- (a) <Button> without onClick/asChild/href/to: ${totals.a}\n`;
+md += `- (b) <button> without onClick and not disabled: ${totals.b}\n`;
+md += `- (c) <a role="button"> without href/to: ${totals.c}\n`;
+md += `- (d) data-testid "-btn" elements without handlers: ${totals.d}\n`;
+md += '\n### Top 10 files by count\n';
+md += topFiles + '\n';
+md += '\n### Suggested minimal fixes\n';
+md += '- Add onClick handlers or link props (href/to) for interactive buttons.\n';
+md += '- Convert <a role="button"> to <Link to="..."> or add href.\n';
+md += '- Ensure data-testid "-btn" elements are wired or removed.\n';
+
+fs.writeFileSync('docs/buttons-static-audit.md', md);
+
+console.log(`Total candidates: ${records.length}`);
+console.log('Rule totals:', totals);
+console.log('Top files:\n' + topFiles);
+


### PR DESCRIPTION
## Summary
- add ts-morph-based script to scan src for unhandled Button-like elements
- record results to artifacts/buttons-static.json and markdown report
- expose script via npm script `audit:buttons:static`

## Testing
- `npm run audit:buttons:static`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9d38b740832d92f75f539e503aca