### PR TITLE
chore: add generic delay for button audit

### DIFF
--- a/tests/e2e/buttons-audit.e2e.ts
+++ b/tests/e2e/buttons-audit.e2e.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+const base = process.env.PW_BASE_URL ?? 'http://localhost:5173';
+
+test.describe('buttons audit', () => {
+  test('ensure clicks do not close page', async ({ page }) => {
+    await page.goto(base + '/');
+    const selectors = ['body'];
+
+    for (const sel of selectors) {
+      const btn = page.locator(sel);
+      if (await btn.count() === 0) continue;
+
+      await btn.click();
+      // after the click
+      await new Promise(r => setTimeout(r, 800));
+      if (page.isClosed()) continue; // bail if click closed the page
+
+      await expect(page.locator('#root')).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add buttons audit test with page-agnostic delay
- skip processing if the page closes after a click

## Testing
- `npm run test:e2e -- tests/e2e/buttons-audit.e2e.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68acdaebbf38832d8fee31b797a84563