### PR TITLE
feat: add UI buttons audit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ bun.lockb
 *.njsproj
 *.sln
 *.sw?
+
+# Test artifacts
+artifacts/*.png
+test-results/

--- a/artifacts/buttons-audit.json
+++ b/artifacts/buttons-audit.json
@@ -1,0 +1,4182 @@
+[
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Proposal",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Create new proposal\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <span>Profile</span> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/New_Proposal.png",
+    "bbox": {
+      "x": 1097.578125,
+      "y": 101,
+      "width": 158.421875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Upload Document",
+    "testid": "upload-agenda-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"upload-agenda-btn\" aria-label=\"Upload new document\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Upload_Document.png",
+    "bbox": {
+      "x": 1065.953125,
+      "y": 101,
+      "width": 190.046875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.relative",
+    "text": "Advanced Filters",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" data-state=\"closed\" aria-expanded=\"false\" aria-haspopup=\"dialog\" aria-controls=\"radix-:r3:\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Advanced_Filters.png",
+    "bbox": {
+      "x": 88,
+      "y": 241,
+      "width": 181.578125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Select All",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Select_All.png",
+    "bbox": {
+      "x": 1120,
+      "y": 330,
+      "width": 111,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 129,
+      "y": 429.75,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 129,
+      "y": 490.5,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": "preview-doc-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"preview-doc-btn\" aria-label=\"Preview Antibiotic Guidelines 2024\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div role=\"separator\" aria-orientation=\"horizontal\" class=\"-mx-1 my-1 h-px bg-muted\"></div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 1043,
+      "y": 482.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Meeting Mode",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Enter meeting mode\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Meeting_Mode.png",
+    "bbox": {
+      "x": 927.515625,
+      "y": 101,
+      "width": 165.046875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Meeting",
+    "testid": "create-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Create new meeting\" data-testid=\"create-meeting-btn\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/New_Meeting.png",
+    "bbox": {
+      "x": 1100.5625,
+      "y": 101,
+      "width": 155.4375,
+      "height": 40
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Edit",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Edit Monthly CFT Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Edit.png",
+    "bbox": {
+      "x": 463.671875,
+      "y": 457,
+      "width": 81.125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3",
+    "text": "Start",
+    "testid": "start-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"start-meeting-btn\" aria-label=\"Join Monthly CFT Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Start.png",
+    "bbox": {
+      "x": 552.796875,
+      "y": 457,
+      "width": 86.203125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Edit",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Edit Emergency Protocol Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Edit.png",
+    "bbox": {
+      "x": 1030.671875,
+      "y": 457,
+      "width": 81.125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3",
+    "text": "Start",
+    "testid": "start-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"start-meeting-btn\" aria-label=\"Join Emergency Protocol Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Start.png",
+    "bbox": {
+      "x": 1119.796875,
+      "y": 457,
+      "width": 86.203125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Minutes",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View minutes for CFT December 2023\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Minutes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/View_Minutes.png",
+    "bbox": {
+      "x": 1087.203125,
+      "y": 819,
+      "width": 118.796875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Minutes",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View minutes for November Urgent Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Minutes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/View_Minutes.png",
+    "bbox": {
+      "x": 1087.203125,
+      "y": 914,
+      "width": 118.796875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.text-primary-foreground.hover:bg-primary/90.h-11.rounded-md.px-8.bg-primary",
+    "text": "Enter Meeting Mode",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(12)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Enter meeting mode for full-screen presentation\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 text-primary-foreground hover:bg-primary/90 h-11 rounded-md px-8 bg-primary\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Enter_Meeting_Mode.png",
+    "bbox": {
+      "x": 553.453125,
+      "y": 1081,
+      "width": 237.078125,
+      "height": 44
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Export proposals to CSV\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Export.png",
+    "bbox": {
+      "x": 977.75,
+      "y": 101,
+      "width": 111.828125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Proposal",
+    "testid": "new-proposal-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"new-proposal-btn\" aria-label=\"Create new proposal\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/New_Proposal.png",
+    "bbox": {
+      "x": 1097.578125,
+      "y": 101,
+      "width": 158.421875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Filters",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Open filter options\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Filters.png",
+    "bbox": {
+      "x": 1123.03125,
+      "y": 328,
+      "width": 107.96875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:re:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:re:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Proposal actions\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 1175,
+      "y": 580.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:rg:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:rg:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Proposal actions\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 1175,
+      "y": 649.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col",
+    "text": "Create Proposal",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Create new proposal\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Create_Proposal.png",
+    "bbox": {
+      "x": 113,
+      "y": 849.5,
+      "width": 362,
+      "height": 80
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col",
+    "text": "Batch Import",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Import multiple proposals\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Batch_Import.png",
+    "bbox": {
+      "x": 491,
+      "y": 639.5,
+      "width": 362,
+      "height": 80
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col",
+    "text": "Schedule Review",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Schedule proposal review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Schedule_Review.png",
+    "bbox": {
+      "x": 869,
+      "y": 639.5,
+      "width": 362,
+      "height": 80
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Add Document",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/Add_Document.png",
+    "bbox": {
+      "x": 1087.90625,
+      "y": 101,
+      "width": 168.09375,
+      "height": 40
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View Pharmaceutical Good Practices Guide\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 1079,
+      "y": 734.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Download Pharmaceutical Good Practices Guide\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 1127,
+      "y": 683.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Create Workflow",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Create_Workflow.png",
+    "bbox": {
+      "x": 1076.734375,
+      "y": 97,
+      "width": 179.265625,
+      "height": 40
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r3:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Status: All",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:r3:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Status_All.png",
+    "bbox": {
+      "x": 552,
+      "y": 279,
+      "width": 137.140625,
+      "height": 40
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-active.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Active (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r5:-trigger-active\" aria-controls=\"radix-:r5:-content-active\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:o…>Active (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Active_0_.png",
+    "bbox": {
+      "x": 92,
+      "y": 347,
+      "width": 91.609375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-all.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "All (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" id=\"radix-:r5:-trigger-all\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" aria-controls=\"radix-:r5:-content-all\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opac…>All (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/All_0_.png",
+    "bbox": {
+      "x": 183.609375,
+      "y": 347,
+      "width": 65.671875,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-completed.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Completed (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r5:-trigger-completed\" aria-controls=\"radix-:r5:-content-completed\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Completed (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Completed_0_.png",
+    "bbox": {
+      "x": 249.28125,
+      "y": 347,
+      "width": 124.671875,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-dashboard.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Dashboard",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-dashboard\" aria-controls=\"radix-:r3:-content-dashboard\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disa…>Dashboard</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Dashboard.png",
+    "bbox": {
+      "x": 92,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-custom.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Custom Views",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-custom\" aria-controls=\"radix-:r3:-content-custom\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Custom Views</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Custom_Views.png",
+    "bbox": {
+      "x": 219.984375,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-export.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Export Reports",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-export\" aria-controls=\"radix-:r3:-content-export\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Export Reports</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Export_Reports.png",
+    "bbox": {
+      "x": 347.96875,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#date.inline-flex.items-center.gap-2.whitespace-nowrap.rounded-md.text-sm.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-[300px].justify-start.text-left.font-normal",
+    "text": "Jul 26, 2025 - Aug 25, 2025",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button id=\"date\" type=\"button\" data-state=\"closed\" aria-expanded=\"false\" aria-haspopup=\"dialog\" aria-controls=\"radix-:r7:\" class=\"inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:t…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Jul_26_2025_Aug_25_2025.png",
+    "bbox": {
+      "x": 700.171875,
+      "y": 245,
+      "width": 300,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32",
+    "text": "Last 30 days",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button dir=\"ltr\" type=\"button\" role=\"combobox\" data-state=\"closed\" aria-expanded=\"false\" aria-autocomplete=\"none\" aria-controls=\"radix-:r8:\" class=\"flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Last_30_days.png",
+    "bbox": {
+      "x": 1008.171875,
+      "y": 245,
+      "width": 128,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r9:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:r9:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Export.png",
+    "bbox": {
+      "x": 1144.171875,
+      "y": 245,
+      "width": 111.828125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-overview.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Overview",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-overview\" aria-controls=\"radix-:rb:-content-overview\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Overview</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Overview.png",
+    "bbox": {
+      "x": 92,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-documents.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Documents",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-documents\" aria-controls=\"radix-:rb:-content-documents\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Documents</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Documents.png",
+    "bbox": {
+      "x": 324,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-proposals.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Proposals",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(12)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-proposals\" aria-controls=\"radix-:rb:-content-proposals\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Proposals</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Proposals.png",
+    "bbox": {
+      "x": 556,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-workflows.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Workflows",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(13)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-workflows\" aria-controls=\"radix-:rb:-content-workflows\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Workflows</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Workflows.png",
+    "bbox": {
+      "x": 788,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-reports.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Reports",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(14)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-reports\" aria-controls=\"radix-:rb:-content-reports\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disab…>Reports</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div class=\"flex flex-col space-y-1\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Reports.png",
+    "bbox": {
+      "x": 1020,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-activity.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Activity Feed",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-activity\" aria-controls=\"radix-:r3:-content-activity\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Activity Feed</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Activity_Feed.png",
+    "bbox": {
+      "x": 92,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-teams.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Team Management",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" id=\"radix-:r3:-trigger-teams\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" aria-controls=\"radix-:r3:-content-teams\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:…>Team Management</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Team_Management.png",
+    "bbox": {
+      "x": 382,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-presence.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Live Collaboration",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-presence\" aria-controls=\"radix-:r3:-content-presence\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Live Collaboration</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Live_Collaboration.png",
+    "bbox": {
+      "x": 672,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-comments.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Comments",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-comments\" aria-controls=\"radix-:r3:-content-comments\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Comments</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div class=\"flex flex-col space-y-1\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Comments.png",
+    "bbox": {
+      "x": 962,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32",
+    "text": "All Activities",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button dir=\"ltr\" type=\"button\" role=\"combobox\" data-state=\"closed\" aria-expanded=\"false\" aria-autocomplete=\"none\" aria-controls=\"radix-:r8:\" class=\"flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/All_Activities.png",
+    "bbox": {
+      "x": 873.703125,
+      "y": 245,
+      "width": 128,
+      "height": 40
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Filter",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Filter.png",
+    "bbox": {
+      "x": 1009.703125,
+      "y": 247,
+      "width": 92.671875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Notifications",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Notifications.png",
+    "bbox": {
+      "x": 1110.375,
+      "y": 247,
+      "width": 145.625,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 281,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 331,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 381,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"true\" data-state=\"checked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 431,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export JSON",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Export_JSON.png",
+    "bbox": {
+      "x": 709,
+      "y": 268,
+      "width": 150.796875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-destructive.text-destructive-foreground.hover:bg-destructive/90.h-10.px-4.py-2",
+    "text": "Clear Log",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Clear_Log.png",
+    "bbox": {
+      "x": 867.796875,
+      "y": 268,
+      "width": 130.078125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Add Test Event",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">Add Test Event</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Add_Test_Event.png",
+    "bbox": {
+      "x": 1005.875,
+      "y": 268,
+      "width": 135.6875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Save Changes",
+    "testid": "save-settings-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"save-settings-btn\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">Save Changes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Save_Changes.png",
+    "bbox": {
+      "x": 113,
+      "y": 452,
+      "width": 131.71875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"true\" data-state=\"checked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 651,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 746,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"true\" data-state=\"checked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 791,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Reconfigure",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">Reconfigure</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Reconfigure.png",
+    "bbox": {
+      "x": 1113.5,
+      "y": 911,
+      "width": 117.5,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Log",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Log</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/View_Log.png",
+    "bbox": {
+      "x": 113,
+      "y": 884,
+      "width": 88.6875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full",
+    "text": "Export Data",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Export_Data.png",
+    "bbox": {
+      "x": 113,
+      "y": 928,
+      "width": 551,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full",
+    "text": "Import Data",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Import_Data.png",
+    "bbox": {
+      "x": 680,
+      "y": 680,
+      "width": 551,
+      "height": 40
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Proposal",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Create new proposal\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <span>Profile</span> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/",
+    "urlAfter": "http://localhost:5173/",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/root/New_Proposal.png",
+    "bbox": {
+      "x": 1097.578125,
+      "y": 101,
+      "width": 158.421875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Upload Document",
+    "testid": "upload-agenda-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"upload-agenda-btn\" aria-label=\"Upload new document\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Upload_Document.png",
+    "bbox": {
+      "x": 1065.953125,
+      "y": 101,
+      "width": 190.046875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.relative",
+    "text": "Advanced Filters",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" data-state=\"closed\" aria-expanded=\"false\" aria-haspopup=\"dialog\" aria-controls=\"radix-:r3:\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Advanced_Filters.png",
+    "bbox": {
+      "x": 88,
+      "y": 241,
+      "width": 181.578125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Select All",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/Select_All.png",
+    "bbox": {
+      "x": 1120,
+      "y": 330,
+      "width": 111,
+      "height": 36
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 129,
+      "y": 429.75,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 129,
+      "y": 490.5,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/documents",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": "preview-doc-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"preview-doc-btn\" aria-label=\"Preview Antibiotic Guidelines 2024\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div role=\"separator\" aria-orientation=\"horizontal\" class=\"-mx-1 my-1 h-px bg-muted\"></div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/documents",
+    "urlAfter": "http://localhost:5173/documents",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_documents/button.png",
+    "bbox": {
+      "x": 1043,
+      "y": 482.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Meeting Mode",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Enter meeting mode\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Meeting_Mode.png",
+    "bbox": {
+      "x": 927.515625,
+      "y": 101,
+      "width": 165.046875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Meeting",
+    "testid": "create-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Create new meeting\" data-testid=\"create-meeting-btn\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/New_Meeting.png",
+    "bbox": {
+      "x": 1100.5625,
+      "y": 101,
+      "width": 155.4375,
+      "height": 40
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Edit",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Edit Monthly CFT Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Edit.png",
+    "bbox": {
+      "x": 463.671875,
+      "y": 457,
+      "width": 81.125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3",
+    "text": "Start",
+    "testid": "start-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"start-meeting-btn\" aria-label=\"Join Monthly CFT Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Start.png",
+    "bbox": {
+      "x": 552.796875,
+      "y": 457,
+      "width": 86.203125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Edit",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Edit Emergency Protocol Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Edit.png",
+    "bbox": {
+      "x": 1030.671875,
+      "y": 457,
+      "width": 81.125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3",
+    "text": "Start",
+    "testid": "start-meeting-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"start-meeting-btn\" aria-label=\"Join Emergency Protocol Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Start.png",
+    "bbox": {
+      "x": 1119.796875,
+      "y": 457,
+      "width": 86.203125,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Minutes",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View minutes for CFT December 2023\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Minutes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/View_Minutes.png",
+    "bbox": {
+      "x": 1087.203125,
+      "y": 819,
+      "width": 118.796875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Minutes",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View minutes for November Urgent Review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Minutes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/View_Minutes.png",
+    "bbox": {
+      "x": 1087.203125,
+      "y": 914,
+      "width": 118.796875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/meetings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.text-primary-foreground.hover:bg-primary/90.h-11.rounded-md.px-8.bg-primary",
+    "text": "Enter Meeting Mode",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(12)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Enter meeting mode for full-screen presentation\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 text-primary-foreground hover:bg-primary/90 h-11 rounded-md px-8 bg-primary\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/meetings",
+    "urlAfter": "http://localhost:5173/meetings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_meetings/Enter_Meeting_Mode.png",
+    "bbox": {
+      "x": 553.453125,
+      "y": 1081,
+      "width": 237.078125,
+      "height": 44
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Export proposals to CSV\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div dir=\"ltr\" role=\"menu\" tabindex=\"-1\" id=\"radix-:r2:\" data-align=\"end\" data-state=\"open\" data-side=\"bottom\" data-radix-menu-content=\"\" aria-orientation=\"vertical\" data-orientation=\"vertical\" aria-labelledby=\"radix-:r1:\" class=\"z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Export.png",
+    "bbox": {
+      "x": 977.75,
+      "y": 101,
+      "width": 111.828125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "New Proposal",
+    "testid": "new-proposal-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"new-proposal-btn\" aria-label=\"Create new proposal\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/New_Proposal.png",
+    "bbox": {
+      "x": 1097.578125,
+      "y": 101,
+      "width": 158.421875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Filters",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Open filter options\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Filters.png",
+    "bbox": {
+      "x": 1123.03125,
+      "y": 328,
+      "width": 107.96875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Filters",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Open filter options\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Filters.png",
+    "bbox": {
+      "x": 1123.03125,
+      "y": 328,
+      "width": 107.96875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:re:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:re:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Proposal actions\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 1175,
+      "y": 580.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button#radix-:rg:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:rg:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Proposal actions\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div class=\"text-sm opacity-90\">Emergency Protocol Update requires review</div> from <div role=\"region\" tabindex=\"-1\" aria-hidden=\"true\" data-aria-hidden=\"true\" aria-label=\"Notifications (F8)\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div class=\"text-sm opacity-90\">Emergency Protocol Update requires review</div> from <div role=\"region\" tabindex=\"-1\" aria-hidden=\"true\" data-aria-hidden=\"true\" aria-label=\"Notifications (F8)\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/button.png",
+    "bbox": {
+      "x": 1175,
+      "y": 649.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col",
+    "text": "Batch Import",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Import multiple proposals\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Batch_Import.png",
+    "bbox": {
+      "x": 491,
+      "y": 849.5,
+      "width": 362,
+      "height": 80
+    }
+  },
+  {
+    "route": "/proposals",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col",
+    "text": "Schedule Review",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Schedule proposal review\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/proposals",
+    "urlAfter": "http://localhost:5173/proposals",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_proposals/Schedule_Review.png",
+    "bbox": {
+      "x": 869,
+      "y": 639.5,
+      "width": 362,
+      "height": 80
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Add Document",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/Add_Document.png",
+    "bbox": {
+      "x": 1087.90625,
+      "y": 101,
+      "width": 168.09375,
+      "height": 40
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"View Pharmaceutical Good Practices Guide\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 1079,
+      "y": 734.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/knowledge",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button aria-label=\"Download Pharmaceutical Good Practices Guide\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/knowledge",
+    "urlAfter": "http://localhost:5173/knowledge",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_knowledge/button.png",
+    "bbox": {
+      "x": 1127,
+      "y": 683.5,
+      "width": 40,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Create Workflow",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Create_Workflow.png",
+    "bbox": {
+      "x": 1076.734375,
+      "y": 97,
+      "width": 179.265625,
+      "height": 40
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r3:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Status: All",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:r3:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Status_All.png",
+    "bbox": {
+      "x": 552,
+      "y": 279,
+      "width": 137.140625,
+      "height": 40
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-active.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Active (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r5:-trigger-active\" aria-controls=\"radix-:r5:-content-active\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:o…>Active (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Active_0_.png",
+    "bbox": {
+      "x": 92,
+      "y": 347,
+      "width": 91.609375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-all.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "All (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" id=\"radix-:r5:-trigger-all\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" aria-controls=\"radix-:r5:-content-all\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opac…>All (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/All_0_.png",
+    "bbox": {
+      "x": 183.609375,
+      "y": 347,
+      "width": 65.671875,
+      "height": 32
+    }
+  },
+  {
+    "route": "/workflows",
+    "selector": "button#radix-:r5:-trigger-completed.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Completed (0)",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r5:-trigger-completed\" aria-controls=\"radix-:r5:-content-completed\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Completed (0)</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/workflows",
+    "urlAfter": "http://localhost:5173/workflows",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_workflows/Completed_0_.png",
+    "bbox": {
+      "x": 249.28125,
+      "y": 347,
+      "width": 124.671875,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-dashboard.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Dashboard",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-dashboard\" aria-controls=\"radix-:r3:-content-dashboard\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disa…>Dashboard</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Dashboard.png",
+    "bbox": {
+      "x": 92,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-custom.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Custom Views",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-custom\" aria-controls=\"radix-:r3:-content-custom\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Custom Views</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Custom_Views.png",
+    "bbox": {
+      "x": 219.984375,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r3:-trigger-export.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Export Reports",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-export\" aria-controls=\"radix-:r3:-content-export\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Export Reports</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Export_Reports.png",
+    "bbox": {
+      "x": 347.96875,
+      "y": 177,
+      "width": 127.984375,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#date.inline-flex.items-center.gap-2.whitespace-nowrap.rounded-md.text-sm.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-[300px].justify-start.text-left.font-normal",
+    "text": "Jul 26, 2025 - Aug 25, 2025",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button id=\"date\" type=\"button\" data-state=\"closed\" aria-expanded=\"false\" aria-haspopup=\"dialog\" aria-controls=\"radix-:r7:\" class=\"inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:t…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Jul_26_2025_Aug_25_2025.png",
+    "bbox": {
+      "x": 700.171875,
+      "y": 245,
+      "width": 300,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32",
+    "text": "Last 30 days",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button dir=\"ltr\" type=\"button\" role=\"combobox\" data-state=\"closed\" aria-expanded=\"false\" aria-autocomplete=\"none\" aria-controls=\"radix-:r8:\" class=\"flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Last_30_days.png",
+    "bbox": {
+      "x": 1008.171875,
+      "y": 245,
+      "width": 128,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:r9:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button type=\"button\" id=\"radix-:r9:\" data-state=\"closed\" aria-haspopup=\"menu\" aria-expanded=\"false\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Export.png",
+    "bbox": {
+      "x": 1144.171875,
+      "y": 245,
+      "width": 111.828125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-overview.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Overview",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-overview\" aria-controls=\"radix-:rb:-content-overview\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Overview</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Overview.png",
+    "bbox": {
+      "x": 92,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-documents.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Documents",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-documents\" aria-controls=\"radix-:rb:-content-documents\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Documents</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Documents.png",
+    "bbox": {
+      "x": 324,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-proposals.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Proposals",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(12)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-proposals\" aria-controls=\"radix-:rb:-content-proposals\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Proposals</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Proposals.png",
+    "bbox": {
+      "x": 556,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-workflows.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Workflows",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(13)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-workflows\" aria-controls=\"radix-:rb:-content-workflows\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Workflows</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Workflows.png",
+    "bbox": {
+      "x": 788,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/analytics",
+    "selector": "button#radix-:rb:-trigger-reports.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Reports",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(14)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:rb:-trigger-reports\" aria-controls=\"radix-:rb:-content-reports\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disab…>Reports</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div class=\"flex flex-col space-y-1\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/analytics",
+    "urlAfter": "http://localhost:5173/analytics",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_analytics/Reports.png",
+    "bbox": {
+      "x": 1020,
+      "y": 431,
+      "width": 232,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-activity.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Activity Feed",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" data-state=\"active\" aria-selected=\"true\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-activity\" aria-controls=\"radix-:r3:-content-activity\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Activity Feed</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Activity_Feed.png",
+    "bbox": {
+      "x": 92,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-teams.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Team Management",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" id=\"radix-:r3:-trigger-teams\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" aria-controls=\"radix-:r3:-content-teams\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:…>Team Management</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Team_Management.png",
+    "bbox": {
+      "x": 382,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-presence.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Live Collaboration",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-presence\" aria-controls=\"radix-:r3:-content-presence\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Live Collaboration</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Live_Collaboration.png",
+    "bbox": {
+      "x": 672,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button#radix-:r3:-trigger-comments.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm",
+    "text": "Comments",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button role=\"tab\" type=\"button\" tabindex=\"-1\" aria-selected=\"false\" data-state=\"inactive\" data-orientation=\"horizontal\" data-radix-collection-item=\"\" id=\"radix-:r3:-trigger-comments\" aria-controls=\"radix-:r3:-content-comments\" class=\"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Comments</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div class=\"flex flex-col space-y-1\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Comments.png",
+    "bbox": {
+      "x": 962,
+      "y": 177,
+      "width": 290,
+      "height": 32
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32",
+    "text": "All Activities",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button dir=\"ltr\" type=\"button\" role=\"combobox\" data-state=\"closed\" aria-expanded=\"false\" aria-autocomplete=\"none\" aria-controls=\"radix-:r8:\" class=\"flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/All_Activities.png",
+    "bbox": {
+      "x": 873.703125,
+      "y": 245,
+      "width": 128,
+      "height": 40
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Filter",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Filter.png",
+    "bbox": {
+      "x": 1009.703125,
+      "y": 247,
+      "width": 92.671875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/collaboration",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "Notifications",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/collaboration",
+    "urlAfter": "http://localhost:5173/collaboration",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_collaboration/Notifications.png",
+    "bbox": {
+      "x": 1110.375,
+      "y": 247,
+      "width": 145.625,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 281,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 331,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\"></button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 381,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"checkbox\" aria-checked=\"true\" data-state=\"checked\" class=\"peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/button.png",
+    "bbox": {
+      "x": 610,
+      "y": 431,
+      "width": 16,
+      "height": 16
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Export JSON",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Export_JSON.png",
+    "bbox": {
+      "x": 709,
+      "y": 268,
+      "width": 150.796875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-destructive.text-destructive-foreground.hover:bg-destructive/90.h-10.px-4.py-2",
+    "text": "Clear Log",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-10 px-4 py-2\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Clear_Log.png",
+    "bbox": {
+      "x": 867.796875,
+      "y": 268,
+      "width": 130.078125,
+      "height": 40
+    }
+  },
+  {
+    "route": "/security",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Add Test Event",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">Add Test Event</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <div tabindex=\"-1\" role=\"menuitem\" data-orientation=\"vertical\" data-radix-collection-item=\"\" class=\"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50\">…</div> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/security",
+    "urlAfter": "http://localhost:5173/security",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_security/Add_Test_Event.png",
+    "bbox": {
+      "x": 1005.875,
+      "y": 268,
+      "width": 135.6875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted",
+    "text": "",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 207,
+      "y": 15.5,
+      "width": 32,
+      "height": 32
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0",
+    "text": "Toggle theme",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Toggle_theme.png",
+    "bbox": {
+      "x": 1132,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative",
+    "text": "2",
+    "testid": null,
+    "status": "OK",
+    "reasons": [
+      "dialog appeared"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "bbox": {
+      "x": 1176,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full",
+    "text": "DR",
+    "testid": null,
+    "status": "Suspicious",
+    "reasons": [
+      "no url change/dialog/dom/network"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/DR.png",
+    "bbox": {
+      "x": 1220,
+      "y": 14,
+      "width": 36,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2",
+    "text": "Save Changes",
+    "testid": "save-settings-btn",
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(4)\u001b[22m\n\u001b[2m    - locator resolved to <button data-testid=\"save-settings-btn\" class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2\">Save Changes</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Save_Changes.png",
+    "bbox": {
+      "x": 113,
+      "y": 452,
+      "width": 131.71875,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(5)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"true\" data-state=\"checked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 651,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(6)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"false\" data-state=\"unchecked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 746,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input",
+    "text": "",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(7)\u001b[22m\n\u001b[2m    - locator resolved to <button value=\"on\" type=\"button\" role=\"switch\" aria-checked=\"true\" data-state=\"checked\" class=\"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-sm font-medium leading-none\">Dr. Rodriguez</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/button.png",
+    "bbox": {
+      "x": 1187,
+      "y": 791,
+      "width": 44,
+      "height": 24
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2",
+    "text": "Reconfigure",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(8)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2\">Reconfigure</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  2 × retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m      - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <p class=\"text-xs leading-none text-muted-foreground\">CFT Administrator</p> from <div dir=\"ltr\" data-radix-popper-content-wrapper=\"\">…</div> subtree intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m    - element is visible, enabled and stable\u001b[22m\n\u001b[2m    - scrolling into view if needed\u001b[22m\n\u001b[2m    - done scrolling\u001b[22m\n\u001b[2m    - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m  - retrying click action\u001b[22m\n\u001b[2m    - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Reconfigure.png",
+    "bbox": {
+      "x": 1113.5,
+      "y": 911,
+      "width": 117.5,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3",
+    "text": "View Log",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(9)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3\">View Log</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/View_Log.png",
+    "bbox": {
+      "x": 113,
+      "y": 884,
+      "width": 88.6875,
+      "height": 36
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full",
+    "text": "Export Data",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(10)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Export_Data.png",
+    "bbox": {
+      "x": 113,
+      "y": 928,
+      "width": 551,
+      "height": 40
+    }
+  },
+  {
+    "route": "/settings",
+    "selector": "button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full",
+    "text": "Import Data",
+    "testid": null,
+    "status": "Broken",
+    "reasons": [
+      "click: locator.click: Timeout 1000ms exceeded.\nCall log:\n\u001b[2m  - waiting for locator('button,[role=\"button\"],[type=\"button\"],a[role=\"button\"],[data-testid$=\"-btn\"],[data-action]').nth(11)\u001b[22m\n\u001b[2m    - locator resolved to <button class=\"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full\">…</button>\u001b[22m\n\u001b[2m  - attempting click action\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m    - waiting 20ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 100ms\u001b[22m\n\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m\n\u001b[2m      - element is visible, enabled and stable\u001b[22m\n\u001b[2m      - scrolling into view if needed\u001b[22m\n\u001b[2m      - done scrolling\u001b[22m\n\u001b[2m      - <html lang=\"en\" class=\"dark\">…</html> intercepts pointer events\u001b[22m\n\u001b[2m    - retrying click action\u001b[22m\n\u001b[2m      - waiting 500ms\u001b[22m\n"
+    ],
+    "urlBefore": "http://localhost:5173/settings",
+    "urlAfter": "http://localhost:5173/settings",
+    "requests": [],
+    "screenshotPath": "test-results/buttons-audit/_settings/Import_Data.png",
+    "bbox": {
+      "x": 680,
+      "y": 680,
+      "width": 551,
+      "height": 40
+    }
+  }
+]

--- a/docs/buttons-audit.md
+++ b/docs/buttons-audit.md
@@ -1,0 +1,2151 @@
+# Buttons Audit
+
+*Screenshots are generated during tests but omitted from version control.*
+
+Routes tested: /, /documents, /meetings, /proposals, /knowledge, /workflows, /analytics, /collaboration, /security, /settings
+
+| Route | Button text | data-testid | Selector | Status | Reason | Screenshot |
+| --- | --- | --- | --- | --- | --- | --- |
+| / |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/root/button.png) |
+| / | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/root/Toggle_theme.png) |
+| / | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| / | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/root/DR.png) |
+| / | New Proposal |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button aria-label="Create new proposal" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <span>Profile</span> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/root/New_Proposal.png) |
+| /documents |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_documents/button.png) |
+| /documents | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_documents/Toggle_theme.png) |
+| /documents | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /documents | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_documents/DR.png) |
+| /documents | Upload Document | upload-agenda-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button data-testid="upload-agenda-btn" aria-label="Upload new document" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/Upload_Document.png) |
+| /documents | Advanced Filters |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.relative` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button type="button" data-state="closed" aria-expanded="false" aria-haspopup="dialog" aria-controls="radix-:r3:" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/Advanced_Filters.png) |
+| /documents | Select All |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/Select_All.png) |
+| /documents |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="false" data-state="unchecked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"></button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/button.png) |
+| /documents |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="false" data-state="unchecked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"></button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/button.png) |
+| /documents |  | preview-doc-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button data-testid="preview-doc-btn" aria-label="Preview Antibiotic Guidelines 2024" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div role="separator" aria-orientation="horizontal" class="-mx-1 my-1 h-px bg-muted"></div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_documents/button.png) |
+| /meetings |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_meetings/button.png) |
+| /meetings | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_meetings/Toggle_theme.png) |
+| /meetings | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /meetings | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_meetings/DR.png) |
+| /meetings | Meeting Mode |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button aria-label="Enter meeting mode" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Meeting_Mode.png) |
+| /meetings | New Meeting | create-meeting-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button aria-label="Create new meeting" data-testid="create-meeting-btn" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/New_Meeting.png) |
+| /meetings | Edit |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button aria-label="Edit Monthly CFT Review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Edit.png) |
+| /meetings | Start | start-meeting-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button data-testid="start-meeting-btn" aria-label="Join Monthly CFT Review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Start.png) |
+| /meetings | Edit |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button aria-label="Edit Emergency Protocol Review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Edit.png) |
+| /meetings | Start | start-meeting-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button data-testid="start-meeting-btn" aria-label="Join Emergency Protocol Review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Start.png) |
+| /meetings | View Minutes |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button aria-label="View minutes for CFT December 2023" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">View Minutes</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/View_Minutes.png) |
+| /meetings | View Minutes |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(11)[22m
+[2m    - locator resolved to <button aria-label="View minutes for November Urgent Review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">View Minutes</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/View_Minutes.png) |
+| /meetings | Enter Meeting Mode |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.text-primary-foreground.hover:bg-primary/90.h-11.rounded-md.px-8.bg-primary` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(12)[22m
+[2m    - locator resolved to <button aria-label="Enter meeting mode for full-screen presentation" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 text-primary-foreground hover:bg-primary/90 h-11 rounded-md px-8 bg-primary">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_meetings/Enter_Meeting_Mode.png) |
+| /proposals |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_proposals/button.png) |
+| /proposals | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_proposals/Toggle_theme.png) |
+| /proposals | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /proposals | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_proposals/DR.png) |
+| /proposals | Export |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button aria-label="Export proposals to CSV" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div dir="ltr" role="menu" tabindex="-1" id="radix-:r2:" data-align="end" data-state="open" data-side="bottom" data-radix-menu-content="" aria-orientation="vertical" data-orientation="vertical" aria-labelledby="radix-:r1:" class="z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div dir="ltr" role="menu" tabindex="-1" id="radix-:r2:" data-align="end" data-state="open" data-side="bottom" data-radix-menu-content="" aria-orientation="vertical" data-orientation="vertical" aria-labelledby="radix-:r1:" class="z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div dir="ltr" role="menu" tabindex="-1" id="radix-:r2:" data-align="end" data-state="open" data-side="bottom" data-radix-menu-content="" aria-orientation="vertical" data-orientation="vertical" aria-labelledby="radix-:r1:" class="z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zo…>…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/Export.png) |
+| /proposals | New Proposal | new-proposal-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button data-testid="new-proposal-btn" aria-label="Create new proposal" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/New_Proposal.png) |
+| /proposals | Filters |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button aria-label="Open filter options" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/Filters.png) |
+| /proposals |  |  | `button#radix-:re:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button type="button" id="radix-:re:" data-state="closed" aria-haspopup="menu" aria-expanded="false" aria-label="Proposal actions" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/button.png) |
+| /proposals |  |  | `button#radix-:rg:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button type="button" id="radix-:rg:" data-state="closed" aria-haspopup="menu" aria-expanded="false" aria-label="Proposal actions" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/button.png) |
+| /proposals | Create Proposal |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button aria-label="Create new proposal" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/Create_Proposal.png) |
+| /proposals | Batch Import |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button aria-label="Import multiple proposals" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/Batch_Import.png) |
+| /proposals | Schedule Review |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.h-20.flex-col` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(11)[22m
+[2m    - locator resolved to <button aria-label="Schedule proposal review" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground px-4 py-2 h-20 flex-col">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_proposals/Schedule_Review.png) |
+| /knowledge |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_knowledge/button.png) |
+| /knowledge | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_knowledge/Toggle_theme.png) |
+| /knowledge | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /knowledge | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_knowledge/DR.png) |
+| /knowledge | Add Document |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_knowledge/Add_Document.png) |
+| /knowledge |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button aria-label="View Pharmaceutical Good Practices Guide" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_knowledge/button.png) |
+| /knowledge |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button aria-label="Download Pharmaceutical Good Practices Guide" class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_knowledge/button.png) |
+| /workflows |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_workflows/button.png) |
+| /workflows | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_workflows/Toggle_theme.png) |
+| /workflows | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /workflows | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_workflows/DR.png) |
+| /workflows | Create Workflow |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_workflows/Create_Workflow.png) |
+| /workflows | Status: All |  | `button#radix-:r3:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button type="button" id="radix-:r3:" data-state="closed" aria-haspopup="menu" aria-expanded="false" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_workflows/Status_All.png) |
+| /workflows | Active (0) |  | `button#radix-:r5:-trigger-active.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" data-state="active" aria-selected="true" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r5:-trigger-active" aria-controls="radix-:r5:-content-active" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:o…>Active (0)</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_workflows/Active_0_.png) |
+| /workflows | All (0) |  | `button#radix-:r5:-trigger-all.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" id="radix-:r5:-trigger-all" data-orientation="horizontal" data-radix-collection-item="" aria-controls="radix-:r5:-content-all" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opac…>All (0)</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_workflows/All_0_.png) |
+| /workflows | Completed (0) |  | `button#radix-:r5:-trigger-completed.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r5:-trigger-completed" aria-controls="radix-:r5:-content-completed" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Completed (0)</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_workflows/Completed_0_.png) |
+| /analytics |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_analytics/button.png) |
+| /analytics | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_analytics/Toggle_theme.png) |
+| /analytics | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /analytics | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_analytics/DR.png) |
+| /analytics | Dashboard |  | `button#radix-:r3:-trigger-dashboard.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" data-state="active" aria-selected="true" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-dashboard" aria-controls="radix-:r3:-content-dashboard" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disa…>Dashboard</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Dashboard.png) |
+| /analytics | Custom Views |  | `button#radix-:r3:-trigger-custom.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-custom" aria-controls="radix-:r3:-content-custom" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Custom Views</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Custom_Views.png) |
+| /analytics | Export Reports |  | `button#radix-:r3:-trigger-export.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-export" aria-controls="radix-:r3:-content-export" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disable…>Export Reports</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Export_Reports.png) |
+| /analytics | Jul 26, 2025 - Aug 25, 2025 |  | `button#date.inline-flex.items-center.gap-2.whitespace-nowrap.rounded-md.text-sm.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-[300px].justify-start.text-left.font-normal` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button id="date" type="button" data-state="closed" aria-expanded="false" aria-haspopup="dialog" aria-controls="radix-:r7:" class="inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:t…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Jul_26_2025_Aug_25_2025.png) |
+| /analytics | Last 30 days |  | `button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button dir="ltr" type="button" role="combobox" data-state="closed" aria-expanded="false" aria-autocomplete="none" aria-controls="radix-:r8:" class="flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Last_30_days.png) |
+| /analytics | Export |  | `button#radix-:r9:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button type="button" id="radix-:r9:" data-state="closed" aria-haspopup="menu" aria-expanded="false" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hov…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Export.png) |
+| /analytics | Overview |  | `button#radix-:rb:-trigger-overview.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" data-state="active" aria-selected="true" data-orientation="horizontal" data-radix-collection-item="" id="radix-:rb:-trigger-overview" aria-controls="radix-:rb:-content-overview" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Overview</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Overview.png) |
+| /analytics | Documents |  | `button#radix-:rb:-trigger-documents.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(11)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:rb:-trigger-documents" aria-controls="radix-:rb:-content-documents" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Documents</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Documents.png) |
+| /analytics | Proposals |  | `button#radix-:rb:-trigger-proposals.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(12)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:rb:-trigger-proposals" aria-controls="radix-:rb:-content-proposals" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Proposals</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Proposals.png) |
+| /analytics | Workflows |  | `button#radix-:rb:-trigger-workflows.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(13)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:rb:-trigger-workflows" aria-controls="radix-:rb:-content-workflows" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none d…>Workflows</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Workflows.png) |
+| /analytics | Reports |  | `button#radix-:rb:-trigger-reports.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(14)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:rb:-trigger-reports" aria-controls="radix-:rb:-content-reports" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disab…>Reports</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div class="flex flex-col space-y-1">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_analytics/Reports.png) |
+| /collaboration |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_collaboration/button.png) |
+| /collaboration | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_collaboration/Toggle_theme.png) |
+| /collaboration | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /collaboration | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_collaboration/DR.png) |
+| /collaboration | Activity Feed |  | `button#radix-:r3:-trigger-activity.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" data-state="active" aria-selected="true" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-activity" aria-controls="radix-:r3:-content-activity" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabl…>Activity Feed</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Activity_Feed.png) |
+| /collaboration | Team Management |  | `button#radix-:r3:-trigger-teams.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" id="radix-:r3:-trigger-teams" data-orientation="horizontal" data-radix-collection-item="" aria-controls="radix-:r3:-content-teams" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:…>Team Management</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Team_Management.png) |
+| /collaboration | Live Collaboration |  | `button#radix-:r3:-trigger-presence.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-presence" aria-controls="radix-:r3:-content-presence" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Live Collaboration</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Live_Collaboration.png) |
+| /collaboration | Comments |  | `button#radix-:r3:-trigger-comments.inline-flex.items-center.justify-center.whitespace-nowrap.rounded-sm.px-3.py-1.5.text-sm.font-medium.ring-offset-background.transition-all.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.data-[state=active]:bg-background.data-[state=active]:text-foreground.data-[state=active]:shadow-sm` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button role="tab" type="button" tabindex="-1" aria-selected="false" data-state="inactive" data-orientation="horizontal" data-radix-collection-item="" id="radix-:r3:-trigger-comments" aria-controls="radix-:r3:-content-comments" class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none dis…>Comments</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div class="flex flex-col space-y-1">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Comments.png) |
+| /collaboration | All Activities |  | `button.flex.h-10.items-center.justify-between.rounded-md.border.border-input.bg-background.px-3.py-2.text-sm.ring-offset-background.placeholder:text-muted-foreground.focus:outline-none.focus:ring-2.focus:ring-ring.focus:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.[&>span]:line-clamp-1.w-32` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button dir="ltr" type="button" role="combobox" data-state="closed" aria-expanded="false" aria-autocomplete="none" aria-controls="radix-:r8:" class="flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 w-32">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/All_Activities.png) |
+| /collaboration | Filter |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Filter.png) |
+| /collaboration | Notifications |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_collaboration/Notifications.png) |
+| /security |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_security/button.png) |
+| /security | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_security/Toggle_theme.png) |
+| /security | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /security | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_security/DR.png) |
+| /security |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="false" data-state="unchecked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"></button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/button.png) |
+| /security |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="false" data-state="unchecked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"></button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/button.png) |
+| /security |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="false" data-state="unchecked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"></button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/button.png) |
+| /security |  |  | `button.peer.h-4.w-4.shrink-0.rounded-sm.border.border-primary.ring-offset-background.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=checked]:text-primary-foreground` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button value="on" type="button" role="checkbox" aria-checked="true" data-state="checked" class="peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/button.png) |
+| /security | Export JSON |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/Export_JSON.png) |
+| /security | Clear Log |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-destructive.text-destructive-foreground.hover:bg-destructive/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/Clear_Log.png) |
+| /security | Add Test Event |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Add Test Event</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_security/Add_Test_Event.png) |
+| /settings |  |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_settings/button.png) |
+| /settings | Toggle theme |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_settings/Toggle_theme.png) |
+| /settings | 2 |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0.relative` | OK | dialog appeared |  |
+| /settings | DR |  | `button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full` | Suspicious | no url change/dialog/dom/network | ![screenshot](test-results/buttons-audit/_settings/DR.png) |
+| /settings | Save Changes | save-settings-btn | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button data-testid="save-settings-btn" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Save Changes</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/Save_Changes.png) |
+| /settings |  |  | `button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button value="on" type="button" role="switch" aria-checked="true" data-state="checked" class="peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-sm font-medium leading-none">Dr. Rodriguez</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/button.png) |
+| /settings |  |  | `button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button value="on" type="button" role="switch" aria-checked="false" data-state="unchecked" class="peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-sm font-medium leading-none">Dr. Rodriguez</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/button.png) |
+| /settings |  |  | `button.peer.inline-flex.h-6.w-11.shrink-0.cursor-pointer.items-center.rounded-full.border-2.border-transparent.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.focus-visible:ring-offset-background.disabled:cursor-not-allowed.disabled:opacity-50.data-[state=checked]:bg-primary.data-[state=unchecked]:bg-input` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(7)[22m
+[2m    - locator resolved to <button value="on" type="button" role="switch" aria-checked="true" data-state="checked" class="peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-sm font-medium leading-none">Dr. Rodriguez</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/button.png) |
+| /settings | Reconfigure |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(8)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">Reconfigure</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/Reconfigure.png) |
+| /settings | View Log |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(9)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">View Log</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/View_Log.png) |
+| /settings | Export Data |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(10)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/Export_Data.png) |
+| /settings | Import Data |  | `button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.w-full` | Broken | click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(11)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+ | ![screenshot](test-results/buttons-audit/_settings/Import_Data.png) |
+
+## Findings
+- /: "" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted) - Suspicious. no url change/dialog/dom/network
+- /: "Toggle theme" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0) - Suspicious. no url change/dialog/dom/network
+- /: "DR" (button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full) - Suspicious. no url change/dialog/dom/network
+- /: "New Proposal" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.bg-primary.text-primary-foreground.hover:bg-primary/90.h-10.px-4.py-2) - Broken. click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button aria-label="Create new proposal" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <span>Profile</span> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+
+- /documents: "" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:text-accent-foreground.rounded-md.h-8.w-8.p-0.hover:bg-muted) - Suspicious. no url change/dialog/dom/network
+- /documents: "Toggle theme" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.rounded-md.h-9.w-9.p-0) - Suspicious. no url change/dialog/dom/network
+- /documents: "DR" (button#radix-:r1:.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.px-4.py-2.relative.h-9.w-9.rounded-full) - Suspicious. no url change/dialog/dom/network
+- /documents: "Upload Document" (upload-agenda-btn) - Broken. click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(4)[22m
+[2m    - locator resolved to <button data-testid="upload-agenda-btn" aria-label="Upload new document" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div tabindex="-1" role="menuitem" data-orientation="vertical" data-radix-collection-item="" class="relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">…</div> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+
+- /documents: "Advanced Filters" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.rounded-md.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.border.border-input.bg-background.hover:bg-accent.hover:text-accent-foreground.h-10.px-4.py-2.relative) - Broken. click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(5)[22m
+[2m    - locator resolved to <button type="button" data-state="closed" aria-expanded="false" aria-haspopup="dialog" aria-controls="radix-:r3:" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:…>…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 500ms[22m
+
+- /documents: "Select All" (button.inline-flex.items-center.justify-center.gap-2.whitespace-nowrap.text-sm.font-medium.ring-offset-background.transition-colors.focus-visible:outline-none.focus-visible:ring-2.focus-visible:ring-ring.focus-visible:ring-offset-2.disabled:pointer-events-none.disabled:opacity-50.[&_svg]:pointer-events-none.[&_svg]:size-4.[&_svg]:shrink-0.hover:bg-accent.hover:text-accent-foreground.h-9.rounded-md.px-3) - Broken. click: locator.click: Timeout 1000ms exceeded.
+Call log:
+[2m  - waiting for locator('button,[role="button"],[type="button"],a[role="button"],[data-testid$="-btn"],[data-action]').nth(6)[22m
+[2m    - locator resolved to <button class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3">…</button>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  2 × retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m      - waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <p class="text-xs leading-none text-muted-foreground">CFT Administrator</p> from <div dir="ltr" data-radix-popper-content-wrapper="">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <html lang="en" class="dark">…</html> intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+
+
+## Audit run output
+
+```
+> vite_react_shadcn_ts@0.0.0 test:e2e
+> playwright test
+
+
+Running 28 tests using 2 workers
+
+  ✓   1 tests/e2e/actions.e2e.ts:18:5 › actions › click new-proposal-btn (5.0s)
+  -   3 tests/e2e/actions.e2e.ts:18:5 › actions › click save-proposal-btn
+  -   4 tests/e2e/actions.e2e.ts:18:5 › actions › click delete-proposal-btn
+  ✓   5 tests/e2e/actions.e2e.ts:18:5 › actions › click upload-agenda-btn (1.9s)
+  -   6 tests/e2e/actions.e2e.ts:18:5 › actions › click preview-doc-btn
+  ✓   2 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route / (11.1s)
+  ✓   7 tests/e2e/actions.e2e.ts:18:5 › actions › click create-meeting-btn (2.0s)
+  ✓   9 tests/e2e/actions.e2e.ts:18:5 › actions › click start-meeting-btn (2.0s)
+  ✓  10 tests/e2e/actions.e2e.ts:18:5 › actions › click save-settings-btn (2.0s)
+  ✓  11 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to / (1.2s)
+  ✓  12 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /documents (1.1s)
+  ✓  13 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /meetings (1.2s)
+  ✓  14 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /proposals (1.1s)
+  ✓  15 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /knowledge (1.1s)
+  ✓  16 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /workflows (1.1s)
+  ✓  17 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /analytics (1.3s)
+  ✓  18 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /collaboration (1.2s)
+  ✓  19 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /security (1.0s)
+  ✓  20 tests/e2e/routes.e2e.ts:12:5 › routes › navigate to /settings (1.1s)
+  ✓   8 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /documents (18.3s)
+  ✓  21 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /meetings (23.4s)
+  ✓  22 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /proposals (21.0s)
+  ✓  23 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /knowledge (11.1s)
+  ✓  24 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /workflows (14.9s)
+  ✓  25 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /analytics (27.4s)
+  ✓  26 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /collaboration (19.1s)
+  ✓  27 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /security (18.9s)
+  ✓  28 tests/e2e/buttons-audit.e2e.ts:43:5 › buttons audit › route /settings (20.8s)
+
+  3 skipped
+  25 passed (3.2m)
+
+```

--- a/docs/runtime-diagnostics.md
+++ b/docs/runtime-diagnostics.md
@@ -24,3 +24,500 @@ npm warn Unknown env config "http-proxy". This will stop working in the next maj
 
 sh: 1: vite: not found
 ```
+
+## dev --debug (pre-audit)
+
+```
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> vite_react_shadcn_ts@0.0.0 dev
+> vite --debug
+
+2025-08-25T21:55:43.969Z vite:config bundled config file loaded in 65.70ms
+2025-08-25T21:55:43.981Z vite:config using resolved config: {
+  server: {
+    preTransformRequests: true,
+    host: '::',
+    port: 8080,
+    sourcemapIgnoreList: [Function: isInNodeModules$1],
+    middlewareMode: false,
+    fs: {
+      strict: true,
+      allow: [Array],
+      deny: [Array],
+      cachedChecks: undefined
+    }
+  },
+  plugins: [
+    'vite:optimized-deps',
+    'vite:watch-package-data',
+    'vite:pre-alias',
+    'alias',
+    'vite:react-babel',
+    'vite:react-refresh',
+    'vite:modulepreload-polyfill',
+    'vite:resolve',
+    'vite:html-inline-proxy',
+    'vite:css',
+    'vite:esbuild',
+    'vite:json',
+    'vite:wasm-helper',
+    'vite:worker',
+    'vite:asset',
+    'vite:wasm-fallback',
+    'vite:define',
+    'vite:css-post',
+    'vite:worker-import-meta-url',
+    'vite:asset-import-meta-url',
+    'vite:dynamic-import-vars',
+    'vite:import-glob',
+    'vite:client-inject',
+    'vite:css-analysis',
+    'vite:import-analysis'
+  ],
+  resolve: {
+    mainFields: [ 'browser', 'module', 'jsnext:main', 'jsnext' ],
+    conditions: [],
+    extensions: [
+      '.mjs',  '.js',
+      '.mts',  '.ts',
+      '.jsx',  '.tsx',
+      '.json'
+    ],
+    dedupe: [],
+    preserveSymlinks: false,
+    alias: [ [Object], [Object], [Object] ]
+  },
+  optimizeDeps: {
+    holdUntilCrawlEnd: true,
+    force: undefined,
+    esbuildOptions: { preserveSymlinks: false, jsx: 'automatic' },
+    include: [
+      'react',
+      'react-dom',
+      'react/jsx-dev-runtime',
+      'react/jsx-runtime'
+    ]
+  },
+  esbuild: { jsxDev: true, jsx: 'automatic', jsxImportSource: undefined },
+  build: {
+    target: [ 'es2020', 'edge88', 'firefox78', 'chrome87', 'safari14' ],
+    cssTarget: [ 'es2020', 'edge88', 'firefox78', 'chrome87', 'safari14' ],
+    outDir: 'dist',
+    assetsDir: 'assets',
+    assetsInlineLimit: 4096,
+    cssCodeSplit: true,
+    sourcemap: false,
+    rollupOptions: { onwarn: [Function: onwarn] },
+    minify: 'esbuild',
+    terserOptions: {},
+    write: true,
+    emptyOutDir: null,
+    copyPublicDir: true,
+    manifest: false,
+    lib: false,
+    ssr: false,
+    ssrManifest: false,
+    ssrEmitAssets: false,
+    reportCompressedSize: true,
+    chunkSizeWarningLimit: 500,
+    watch: null,
+    commonjsOptions: { include: [Array], extensions: [Array] },
+    dynamicImportVarsOptions: { warnOnError: true, exclude: [Array] },
+    modulePreload: { polyfill: true },
+    cssMinify: true
+  },
+  configFile: '/workspace/Synapse/vite.config.ts',
+  configFileDependencies: [ '/workspace/Synapse/vite.config.ts' ],
+  inlineConfig: {
+    root: undefined,
+    base: undefined,
+    mode: undefined,
+    configFile: undefined,
+    logLevel: undefined,
+    clearScreen: undefined,
+    optimizeDeps: { force: undefined },
+    server: { host: undefined }
+  },
+  root: '/workspace/Synapse',
+  base: '/',
+  decodedBase: '/',
+  rawBase: '/',
+  publicDir: '/workspace/Synapse/public',
+  cacheDir: '/workspace/Synapse/node_modules/.vite',
+  command: 'serve',
+  mode: 'development',
+  ssr: {
+    target: 'node',
+    optimizeDeps: { noDiscovery: true, esbuildOptions: [Object] }
+  },
+  isWorker: false,
+  mainConfig: null,
+  bundleChain: [],
+  isProduction: false,
+  css: { lightningcss: undefined },
+  preview: {
+    port: undefined,
+    strictPort: undefined,
+    host: '::',
+    allowedHosts: undefined,
+    https: undefined,
+    open: undefined,
+    proxy: undefined,
+    cors: undefined,
+    headers: undefined
+  },
+  envDir: '/workspace/Synapse',
+  env: { BASE_URL: '/', MODE: 'development', DEV: true, PROD: false },
+  assetsInclude: [Function: assetsInclude],
+  logger: {
+    hasWarned: false,
+    info: [Function: info],
+    warn: [Function: warn],
+    warnOnce: [Function: warnOnce],
+    error: [Function: error],
+    clearScreen: [Function: clearScreen],
+    hasErrorLogged: [Function: hasErrorLogged]
+  },
+  packageCache: Map(1) {
+    'fnpd_/workspace/Synapse' => {
+      dir: '/workspace/Synapse',
+      data: [Object],
+      hasSideEffects: [Function: hasSideEffects],
+      webResolvedImports: {},
+      nodeResolvedImports: {},
+      setResolvedCache: [Function: setResolvedCache],
+      getResolvedCache: [Function: getResolvedCache]
+    },
+    set: [Function (anonymous)]
+  },
+  createResolver: [Function: createResolver],
+  worker: { format: 'iife', plugins: '() => plugins', rollupOptions: {} },
+  appType: 'spa',
+  experimental: { importGlobRestoreExtension: false, hmrPartialAccept: false },
+  webSocketToken: 'A_NFzmdWFpjX',
+  additionalAllowedHosts: [ '::', '::' ],
+  getSortedPlugins: [Function: getSortedPlugins],
+  getSortedPluginHooks: [Function: getSortedPluginHooks]
+}
+2025-08-25T21:55:44.002Z vite:deps removing old cache dir /workspace/Synapse/node_modules/.vite/deps
+2025-08-25T21:55:44.013Z vite:resolve 1.47ms react -> /workspace/Synapse/node_modules/react/index.js
+2025-08-25T21:55:44.014Z vite:resolve 0.49ms react-dom -> /workspace/Synapse/node_modules/react-dom/index.js
+2025-08-25T21:55:44.014Z vite:resolve 0.22ms react/jsx-dev-runtime -> /workspace/Synapse/node_modules/react/jsx-dev-runtime.js
+2025-08-25T21:55:44.015Z vite:resolve 0.13ms react/jsx-runtime -> /workspace/Synapse/node_modules/react/jsx-runtime.js
+2025-08-25T21:55:44.017Z vite:deps scanning for dependencies...
+
+  VITE v5.4.19  ready in 318 ms
+
+  ➜  Local:   http://localhost:8080/
+  ➜  Network: http://172.30.1.98:8080/
+  ➜  press h + enter to show help
+2025-08-25T21:55:44.060Z vite:deps Crawling dependencies using entries: 
+  /workspace/Synapse/index.html
+2025-08-25T21:55:44.374Z vite:resolve 0.36ms /src/main.tsx -> /workspace/Synapse/src/main.tsx
+2025-08-25T21:55:44.377Z vite:resolve 0.66ms react-dom/client -> /workspace/Synapse/node_modules/react-dom/client.js
+2025-08-25T21:55:44.378Z vite:resolve 0.13ms ./App.tsx -> /workspace/Synapse/src/App.tsx
+2025-08-25T21:55:44.379Z vite:resolve 0.24ms react/jsx-runtime -> /workspace/Synapse/node_modules/react/jsx-runtime.js
+2025-08-25T21:55:44.381Z vite:resolve 0.34ms /workspace/Synapse/src/components/ui/toaster -> /workspace/Synapse/src/components/ui/toaster.tsx
+2025-08-25T21:55:44.382Z vite:resolve 0.58ms @/components/ui/toaster -> /workspace/Synapse/src/components/ui/toaster.tsx
+2025-08-25T21:55:44.382Z vite:resolve 0.14ms /workspace/Synapse/src/components/ui/sonner -> /workspace/Synapse/src/components/ui/sonner.tsx
+2025-08-25T21:55:44.382Z vite:resolve 0.23ms @/components/ui/sonner -> /workspace/Synapse/src/components/ui/sonner.tsx
+2025-08-25T21:55:44.383Z vite:resolve 0.08ms /workspace/Synapse/src/components/ui/tooltip -> /workspace/Synapse/src/components/ui/tooltip.tsx
+2025-08-25T21:55:44.383Z vite:resolve 0.17ms @/components/ui/tooltip -> /workspace/Synapse/src/components/ui/tooltip.tsx
+2025-08-25T21:55:44.383Z vite:resolve 0.45ms @tanstack/react-query -> /workspace/Synapse/node_modules/@tanstack/react-query/build/modern/index.js
+2025-08-25T21:55:44.384Z vite:resolve 0.31ms react-router-dom -> /workspace/Synapse/node_modules/react-router-dom/dist/index.js
+2025-08-25T21:55:44.385Z vite:resolve 0.44ms next-themes -> /workspace/Synapse/node_modules/next-themes/dist/index.mjs
+2025-08-25T21:55:44.385Z vite:resolve 0.11ms ./components/layout/AppLayout -> /workspace/Synapse/src/components/layout/AppLayout.tsx
+2025-08-25T21:55:44.386Z vite:resolve 0.11ms ./pages/Dashboard -> /workspace/Synapse/src/pages/Dashboard.tsx
+2025-08-25T21:55:44.386Z vite:resolve 0.11ms ./pages/Documents -> /workspace/Synapse/src/pages/Documents.tsx
+2025-08-25T21:55:44.387Z vite:resolve 0.19ms ./pages/Meetings -> /workspace/Synapse/src/pages/Meetings.tsx
+2025-08-25T21:55:44.387Z vite:resolve 0.13ms ./pages/Proposals -> /workspace/Synapse/src/pages/Proposals.tsx
+2025-08-25T21:55:44.387Z vite:resolve 0.09ms ./pages/Knowledge -> /workspace/Synapse/src/pages/Knowledge.tsx
+2025-08-25T21:55:44.388Z vite:resolve 0.13ms ./pages/Settings -> /workspace/Synapse/src/pages/Settings.tsx
+2025-08-25T21:55:44.389Z vite:resolve 0.14ms ./pages/Workflows -> /workspace/Synapse/src/pages/Workflows.tsx
+2025-08-25T21:55:44.389Z vite:resolve 0.09ms ./pages/Analytics -> /workspace/Synapse/src/pages/Analytics.tsx
+2025-08-25T21:55:44.390Z vite:resolve 0.13ms ./pages/Collaboration -> /workspace/Synapse/src/pages/Collaboration.tsx
+2025-08-25T21:55:44.391Z vite:resolve 0.11ms ./pages/Security -> /workspace/Synapse/src/pages/Security.tsx
+2025-08-25T21:55:44.392Z vite:resolve 0.14ms ./pages/NotFound -> /workspace/Synapse/src/pages/NotFound.tsx
+2025-08-25T21:55:44.392Z vite:resolve 0.09ms /workspace/Synapse/src/hooks/use-auth -> /workspace/Synapse/src/hooks/use-auth.tsx
+2025-08-25T21:55:44.392Z vite:resolve 0.16ms @/hooks/use-auth -> /workspace/Synapse/src/hooks/use-auth.tsx
+2025-08-25T21:55:44.393Z vite:resolve 0.06ms /workspace/Synapse/src/hooks/use-audit-log -> /workspace/Synapse/src/hooks/use-audit-log.tsx
+2025-08-25T21:55:44.393Z vite:resolve 0.13ms @/hooks/use-audit-log -> /workspace/Synapse/src/hooks/use-audit-log.tsx
+2025-08-25T21:55:44.401Z vite:resolve 0.47ms react -> /workspace/Synapse/node_modules/react/index.js
+2025-08-25T21:55:44.403Z vite:resolve 1.71ms /workspace/Synapse/src/hooks/use-toast -> /workspace/Synapse/src/hooks/use-toast.ts
+2025-08-25T21:55:44.403Z vite:resolve 1.80ms @/hooks/use-toast -> /workspace/Synapse/src/hooks/use-toast.ts
+2025-08-25T21:55:44.404Z vite:resolve 1.14ms ./AppSidebar -> /workspace/Synapse/src/components/layout/AppSidebar.tsx
+2025-08-25T21:55:44.404Z vite:resolve 1.14ms @radix-ui/react-tooltip -> /workspace/Synapse/node_modules/@radix-ui/react-tooltip/dist/index.mjs
+2025-08-25T21:55:44.409Z vite:resolve 0.96ms ./AppHeader -> /workspace/Synapse/src/components/layout/AppHeader.tsx
+2025-08-25T21:55:44.409Z vite:resolve 0.99ms sonner -> /workspace/Synapse/node_modules/sonner/dist/index.mjs
+2025-08-25T21:55:44.409Z vite:resolve 1.13ms /workspace/Synapse/src/lib/utils -> /workspace/Synapse/src/lib/utils.ts
+2025-08-25T21:55:44.409Z vite:resolve 1.37ms @/lib/utils -> /workspace/Synapse/src/lib/utils.ts
+2025-08-25T21:55:44.410Z vite:resolve 0.35ms /workspace/Synapse/src/components/workflow/WorkflowManager -> /workspace/Synapse/src/components/workflow/WorkflowManager.tsx
+2025-08-25T21:55:44.410Z vite:resolve 0.54ms @/components/workflow/WorkflowManager -> /workspace/Synapse/src/components/workflow/WorkflowManager.tsx
+2025-08-25T21:55:44.411Z vite:resolve 0.40ms lucide-react -> /workspace/Synapse/node_modules/lucide-react/dist/esm/lucide-react.js
+2025-08-25T21:55:44.412Z vite:resolve 0.29ms ./PWAPrompt -> /workspace/Synapse/src/components/layout/PWAPrompt.tsx
+2025-08-25T21:55:44.413Z vite:resolve 0.09ms /workspace/Synapse/src/components/ui/card -> /workspace/Synapse/src/components/ui/card.tsx
+2025-08-25T21:55:44.413Z vite:resolve 0.32ms @/components/ui/card -> /workspace/Synapse/src/components/ui/card.tsx
+2025-08-25T21:55:44.417Z vite:resolve 0.18ms /workspace/Synapse/src/components/dashboard/KPICard -> /workspace/Synapse/src/components/dashboard/KPICard.tsx
+2025-08-25T21:55:44.417Z vite:resolve 0.24ms /workspace/Synapse/src/hooks/use-mobile -> /workspace/Synapse/src/hooks/use-mobile.tsx
+2025-08-25T21:55:44.417Z vite:resolve 0.55ms @/components/dashboard/KPICard -> /workspace/Synapse/src/components/dashboard/KPICard.tsx
+2025-08-25T21:55:44.417Z vite:resolve 0.47ms @/hooks/use-mobile -> /workspace/Synapse/src/hooks/use-mobile.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.37ms /workspace/Synapse/src/components/ui/toast -> /workspace/Synapse/src/components/ui/toast.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.40ms /workspace/Synapse/src/components/collaboration/CollaborationHub -> /workspace/Synapse/src/components/collaboration/CollaborationHub.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.41ms /workspace/Synapse/src/components/ui/button -> /workspace/Synapse/src/components/ui/button.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.72ms @/components/ui/toast -> /workspace/Synapse/src/components/ui/toast.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.71ms @/components/collaboration/CollaborationHub -> /workspace/Synapse/src/components/collaboration/CollaborationHub.tsx
+2025-08-25T21:55:44.418Z vite:resolve 0.69ms @/components/ui/button -> /workspace/Synapse/src/components/ui/button.tsx
+2025-08-25T21:55:44.422Z vite:resolve 0.09ms /workspace/Synapse/src/components/ui/tabs -> /workspace/Synapse/src/components/ui/tabs.tsx
+2025-08-25T21:55:44.422Z vite:resolve 0.18ms @/components/ui/tabs -> /workspace/Synapse/src/components/ui/tabs.tsx
+2025-08-25T21:55:44.423Z vite:resolve 0.13ms /workspace/Synapse/src/components/ui/badge -> /workspace/Synapse/src/components/ui/badge.tsx
+2025-08-25T21:55:44.423Z vite:resolve 0.61ms @/components/ui/badge -> /workspace/Synapse/src/components/ui/badge.tsx
+2025-08-25T21:55:44.425Z vite:resolve 0.12ms /workspace/Synapse/src/components/analytics/AnalyticsDashboard -> /workspace/Synapse/src/components/analytics/AnalyticsDashboard.tsx
+2025-08-25T21:55:44.425Z vite:resolve 0.93ms @/components/analytics/AnalyticsDashboard -> /workspace/Synapse/src/components/analytics/AnalyticsDashboard.tsx
+2025-08-25T21:55:44.427Z vite:resolve 0.73ms clsx -> /workspace/Synapse/node_modules/clsx/dist/clsx.mjs
+2025-08-25T21:55:44.427Z vite:resolve 0.76ms /workspace/Synapse/src/components/ui/input -> /workspace/Synapse/src/components/ui/input.tsx
+2025-08-25T21:55:44.427Z vite:resolve 1.20ms /workspace/Synapse/src/hooks/use-loading -> /workspace/Synapse/src/hooks/use-loading.ts
+2025-08-25T21:55:44.428Z vite:resolve 1.23ms /workspace/Synapse/src/components/ui/checkbox -> /workspace/Synapse/src/components/ui/checkbox.tsx
+2025-08-25T21:55:44.428Z vite:resolve 1.24ms /workspace/Synapse/src/components/analytics/ExportManager -> /workspace/Synapse/src/components/analytics/ExportManager.tsx
+2025-08-25T21:55:44.428Z vite:resolve 1.61ms @/components/ui/input -> /workspace/Synapse/src/components/ui/input.tsx
+2025-08-25T21:55:44.428Z vite:resolve 1.59ms @/hooks/use-loading -> /workspace/Synapse/src/hooks/use-loading.ts
+2025-08-25T21:55:44.428Z vite:resolve 1.49ms @/components/ui/checkbox -> /workspace/Synapse/src/components/ui/checkbox.tsx
+2025-08-25T21:55:44.428Z vite:resolve 1.45ms @/components/analytics/ExportManager -> /workspace/Synapse/src/components/analytics/ExportManager.tsx
+2025-08-25T21:55:44.431Z vite:resolve 0.57ms tailwind-merge -> /workspace/Synapse/node_modules/tailwind-merge/dist/bundle-mjs.mjs
+2025-08-25T21:55:44.431Z vite:resolve 0.50ms /workspace/Synapse/src/components/ui/table -> /workspace/Synapse/src/components/ui/table.tsx
+2025-08-25T21:55:44.431Z vite:resolve 0.76ms @/components/ui/table -> /workspace/Synapse/src/components/ui/table.tsx
+2025-08-25T21:55:44.431Z vite:resolve 0.22ms /workspace/Synapse/src/lib/error-handling -> /workspace/Synapse/src/lib/error-handling.ts
+2025-08-25T21:55:44.431Z vite:resolve 0.25ms /workspace/Synapse/src/services/meeting-service -> /workspace/Synapse/src/services/meeting-service.ts
+2025-08-25T21:55:44.432Z vite:resolve 0.26ms /workspace/Synapse/src/components/analytics/CustomDashboard -> /workspace/Synapse/src/components/analytics/CustomDashboard.tsx
+2025-08-25T21:55:44.432Z vite:resolve 0.46ms @/lib/error-handling -> /workspace/Synapse/src/lib/error-handling.ts
+2025-08-25T21:55:44.432Z vite:resolve 0.43ms @/services/meeting-service -> /workspace/Synapse/src/services/meeting-service.ts
+2025-08-25T21:55:44.432Z vite:resolve 0.43ms @/components/analytics/CustomDashboard -> /workspace/Synapse/src/components/analytics/CustomDashboard.tsx
+2025-08-25T21:55:44.439Z vite:resolve 2.67ms date-fns -> /workspace/Synapse/node_modules/date-fns/index.mjs
+2025-08-25T21:55:44.439Z vite:resolve 2.53ms /workspace/Synapse/src/services/document-service -> /workspace/Synapse/src/services/document-service.ts
+2025-08-25T21:55:44.439Z vite:resolve 2.56ms /workspace/Synapse/src/components/ui/chart -> /workspace/Synapse/src/components/ui/chart.tsx
+2025-08-25T21:55:44.439Z vite:resolve 2.57ms /workspace/Synapse/src/components/ui/label -> /workspace/Synapse/src/components/ui/label.tsx
+2025-08-25T21:55:44.439Z vite:resolve 2.98ms @/services/document-service -> /workspace/Synapse/src/services/document-service.ts
+2025-08-25T21:55:44.439Z vite:resolve 2.97ms @/components/ui/chart -> /workspace/Synapse/src/components/ui/chart.tsx
+2025-08-25T21:55:44.439Z vite:resolve 2.97ms @/components/ui/label -> /workspace/Synapse/src/components/ui/label.tsx
+2025-08-25T21:55:44.440Z vite:resolve 0.92ms recharts -> /workspace/Synapse/node_modules/recharts/es6/index.js
+2025-08-25T21:55:44.441Z vite:resolve 0.72ms /workspace/Synapse/src/components/dialogs/DocumentUploadDialog -> /workspace/Synapse/src/components/dialogs/DocumentUploadDialog.tsx
+2025-08-25T21:55:44.441Z vite:resolve 1.22ms @/components/dialogs/DocumentUploadDialog -> /workspace/Synapse/src/components/dialogs/DocumentUploadDialog.tsx
+2025-08-25T21:55:44.441Z vite:resolve 0.07ms /workspace/Synapse/src/components/ui/switch -> /workspace/Synapse/src/components/ui/switch.tsx
+2025-08-25T21:55:44.441Z vite:resolve 0.13ms @/components/ui/switch -> /workspace/Synapse/src/components/ui/switch.tsx
+2025-08-25T21:55:44.443Z vite:resolve 0.72ms ./CommentSystem -> /workspace/Synapse/src/components/collaboration/CommentSystem.tsx
+2025-08-25T21:55:44.443Z vite:resolve 0.41ms /workspace/Synapse/src/components/ui/dropdown-menu -> /workspace/Synapse/src/components/ui/dropdown-menu.tsx
+2025-08-25T21:55:44.443Z vite:resolve 0.43ms /workspace/Synapse/src/components/ui/confirm-dialog -> /workspace/Synapse/src/components/ui/confirm-dialog.tsx
+2025-08-25T21:55:44.443Z vite:resolve 0.44ms /workspace/Synapse/src/components/ui/separator -> /workspace/Synapse/src/components/ui/separator.tsx
+2025-08-25T21:55:44.443Z vite:resolve 1.04ms @/components/ui/dropdown-menu -> /workspace/Synapse/src/components/ui/dropdown-menu.tsx
+2025-08-25T21:55:44.443Z vite:resolve 1.02ms @/components/ui/confirm-dialog -> /workspace/Synapse/src/components/ui/confirm-dialog.tsx
+2025-08-25T21:55:44.443Z vite:resolve 0.71ms @/components/ui/separator -> /workspace/Synapse/src/components/ui/separator.tsx
+2025-08-25T21:55:44.447Z vite:resolve 0.83ms @radix-ui/react-toast -> /workspace/Synapse/node_modules/@radix-ui/react-toast/dist/index.mjs
+2025-08-25T21:55:44.447Z vite:resolve 0.84ms ./TeamManagement -> /workspace/Synapse/src/components/collaboration/TeamManagement.tsx
+2025-08-25T21:55:44.448Z vite:resolve 0.78ms /workspace/Synapse/src/components/documents/DocumentPreviewDialog -> /workspace/Synapse/src/components/documents/DocumentPreviewDialog.tsx
+2025-08-25T21:55:44.448Z vite:resolve 0.82ms /workspace/Synapse/src/components/ui/avatar -> /workspace/Synapse/src/components/ui/avatar.tsx
+2025-08-25T21:55:44.448Z vite:resolve 0.84ms /workspace/Synapse/src/components/dialogs/AuditLogDialog -> /workspace/Synapse/src/components/dialogs/AuditLogDialog.tsx
+2025-08-25T21:55:44.448Z vite:resolve 1.21ms @/components/documents/DocumentPreviewDialog -> /workspace/Synapse/src/components/documents/DocumentPreviewDialog.tsx
+2025-08-25T21:55:44.448Z vite:resolve 1.20ms @/components/ui/avatar -> /workspace/Synapse/src/components/ui/avatar.tsx
+2025-08-25T21:55:44.448Z vite:resolve 1.21ms @/components/dialogs/AuditLogDialog -> /workspace/Synapse/src/components/dialogs/AuditLogDialog.tsx
+2025-08-25T21:55:44.449Z vite:resolve 1.06ms @radix-ui/react-tabs -> /workspace/Synapse/node_modules/@radix-ui/react-tabs/dist/index.mjs
+2025-08-25T21:55:44.449Z vite:resolve 1.09ms class-variance-authority -> /workspace/Synapse/node_modules/class-variance-authority/dist/index.mjs
+2025-08-25T21:55:44.449Z vite:resolve 1.11ms ./ActivityFeed -> /workspace/Synapse/src/components/collaboration/ActivityFeed.tsx
+2025-08-25T21:55:44.450Z vite:resolve 1.10ms /workspace/Synapse/src/services/proposal-service -> /workspace/Synapse/src/services/proposal-service.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.12ms /workspace/Synapse/src/services/knowledge-service -> /workspace/Synapse/src/services/knowledge-service.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.12ms /workspace/Synapse/src/hooks/use-pwa -> /workspace/Synapse/src/hooks/use-pwa.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.12ms /workspace/Synapse/src/components/documents/DocumentVersionDialog -> /workspace/Synapse/src/components/documents/DocumentVersionDialog.tsx
+2025-08-25T21:55:44.450Z vite:resolve 1.49ms @/services/proposal-service -> /workspace/Synapse/src/services/proposal-service.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.46ms @/services/knowledge-service -> /workspace/Synapse/src/services/knowledge-service.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.47ms @/hooks/use-pwa -> /workspace/Synapse/src/hooks/use-pwa.ts
+2025-08-25T21:55:44.450Z vite:resolve 1.48ms @/components/documents/DocumentVersionDialog -> /workspace/Synapse/src/components/documents/DocumentVersionDialog.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.51ms ./CollaborationPresence -> /workspace/Synapse/src/components/collaboration/CollaborationPresence.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.49ms /workspace/Synapse/src/components/notifications/NotificationCenter -> /workspace/Synapse/src/components/notifications/NotificationCenter.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.52ms /workspace/Synapse/src/services/settings-service -> /workspace/Synapse/src/services/settings-service.ts
+2025-08-25T21:55:44.451Z vite:resolve 0.53ms /workspace/Synapse/src/components/ui/progress -> /workspace/Synapse/src/components/ui/progress.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.53ms /workspace/Synapse/src/components/documents/DocumentFilters -> /workspace/Synapse/src/components/documents/DocumentFilters.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.86ms @/components/notifications/NotificationCenter -> /workspace/Synapse/src/components/notifications/NotificationCenter.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.86ms @/services/settings-service -> /workspace/Synapse/src/services/settings-service.ts
+2025-08-25T21:55:44.451Z vite:resolve 0.79ms @/components/ui/progress -> /workspace/Synapse/src/components/ui/progress.tsx
+2025-08-25T21:55:44.451Z vite:resolve 0.78ms @/components/documents/DocumentFilters -> /workspace/Synapse/src/components/documents/DocumentFilters.tsx
+2025-08-25T21:55:44.456Z vite:resolve 2.92ms ./MobileNav -> /workspace/Synapse/src/components/layout/MobileNav.tsx
+2025-08-25T21:55:44.456Z vite:resolve 0.28ms /workspace/Synapse/src/components/documents/DocumentTableSkeleton -> /workspace/Synapse/src/components/documents/DocumentTableSkeleton.tsx
+2025-08-25T21:55:44.456Z vite:resolve 0.84ms @/components/documents/DocumentTableSkeleton -> /workspace/Synapse/src/components/documents/DocumentTableSkeleton.tsx
+2025-08-25T21:55:44.467Z vite:resolve 0.82ms @radix-ui/react-slot -> /workspace/Synapse/node_modules/@radix-ui/react-slot/dist/index.mjs
+2025-08-25T21:55:44.468Z vite:resolve 0.25ms /workspace/Synapse/src/components/ui/dialog -> /workspace/Synapse/src/components/ui/dialog.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.34ms /workspace/Synapse/src/components/ui/select -> /workspace/Synapse/src/components/ui/select.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.37ms /workspace/Synapse/src/components/ui/alert-dialog -> /workspace/Synapse/src/components/ui/alert-dialog.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.38ms /workspace/Synapse/src/hooks/use-keyboard-shortcuts -> /workspace/Synapse/src/hooks/use-keyboard-shortcuts.ts
+2025-08-25T21:55:44.468Z vite:resolve 0.94ms @/components/ui/dialog -> /workspace/Synapse/src/components/ui/dialog.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.89ms @/components/ui/select -> /workspace/Synapse/src/components/ui/select.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.87ms @/components/ui/alert-dialog -> /workspace/Synapse/src/components/ui/alert-dialog.tsx
+2025-08-25T21:55:44.468Z vite:resolve 0.84ms @/hooks/use-keyboard-shortcuts -> /workspace/Synapse/src/hooks/use-keyboard-shortcuts.ts
+2025-08-25T21:55:44.487Z vite:resolve 17.69ms @radix-ui/react-checkbox -> /workspace/Synapse/node_modules/@radix-ui/react-checkbox/dist/index.mjs
+2025-08-25T21:55:44.489Z vite:resolve 0.17ms /workspace/Synapse/src/hooks/use-workflow -> /workspace/Synapse/src/hooks/use-workflow.ts
+2025-08-25T21:55:44.489Z vite:resolve 0.93ms @/hooks/use-workflow -> /workspace/Synapse/src/hooks/use-workflow.ts
+2025-08-25T21:55:44.490Z vite:resolve 0.37ms ./WorkflowCreateDialog -> /workspace/Synapse/src/components/workflow/WorkflowCreateDialog.tsx
+2025-08-25T21:55:44.492Z vite:resolve 0.37ms ./WorkflowStepDialog -> /workspace/Synapse/src/components/workflow/WorkflowStepDialog.tsx
+2025-08-25T21:55:44.492Z vite:resolve 0.32ms /workspace/Synapse/src/components/ui/date-range-picker -> /workspace/Synapse/src/components/ui/date-range-picker.tsx
+2025-08-25T21:55:44.492Z vite:resolve 0.52ms @/components/ui/date-range-picker -> /workspace/Synapse/src/components/ui/date-range-picker.tsx
+2025-08-25T21:55:44.500Z vite:resolve 0.59ms ./AdvancedChart -> /workspace/Synapse/src/components/analytics/AdvancedChart.tsx
+2025-08-25T21:55:44.504Z vite:resolve 1.63ms @radix-ui/react-label -> /workspace/Synapse/node_modules/@radix-ui/react-label/dist/index.mjs
+2025-08-25T21:55:44.504Z vite:resolve 1.59ms @radix-ui/react-separator -> /workspace/Synapse/node_modules/@radix-ui/react-separator/dist/index.mjs
+2025-08-25T21:55:44.504Z vite:resolve 1.60ms @radix-ui/react-switch -> /workspace/Synapse/node_modules/@radix-ui/react-switch/dist/index.mjs
+2025-08-25T21:55:44.505Z vite:resolve 1.09ms /workspace/Synapse/src/hooks/use-analytics -> /workspace/Synapse/src/hooks/use-analytics.ts
+2025-08-25T21:55:44.505Z vite:resolve 1.59ms @/hooks/use-analytics -> /workspace/Synapse/src/hooks/use-analytics.ts
+2025-08-25T21:55:44.506Z vite:resolve 0.62ms @radix-ui/react-dropdown-menu -> /workspace/Synapse/node_modules/@radix-ui/react-dropdown-menu/dist/index.mjs
+2025-08-25T21:55:44.506Z vite:resolve 0.61ms @radix-ui/react-avatar -> /workspace/Synapse/node_modules/@radix-ui/react-avatar/dist/index.mjs
+2025-08-25T21:55:44.512Z vite:resolve 0.14ms /workspace/Synapse/src/components/ui/skeleton -> /workspace/Synapse/src/components/ui/skeleton.tsx
+2025-08-25T21:55:44.512Z vite:resolve 0.24ms @/components/ui/skeleton -> /workspace/Synapse/src/components/ui/skeleton.tsx
+2025-08-25T21:55:44.514Z vite:resolve 0.78ms @radix-ui/react-alert-dialog -> /workspace/Synapse/node_modules/@radix-ui/react-alert-dialog/dist/index.mjs
+2025-08-25T21:55:44.514Z vite:resolve 0.16ms /workspace/Synapse/src/components/ui/textarea -> /workspace/Synapse/src/components/ui/textarea.tsx
+2025-08-25T21:55:44.514Z vite:resolve 0.29ms @/components/ui/textarea -> /workspace/Synapse/src/components/ui/textarea.tsx
+2025-08-25T21:55:44.516Z vite:resolve 0.18ms ./MetricsGrid -> /workspace/Synapse/src/components/analytics/MetricsGrid.tsx
+2025-08-25T21:55:44.519Z vite:resolve 0.08ms /workspace/Synapse/src/components/ui/sheet -> /workspace/Synapse/src/components/ui/sheet.tsx
+2025-08-25T21:55:44.519Z vite:resolve 0.31ms @/components/ui/sheet -> /workspace/Synapse/src/components/ui/sheet.tsx
+2025-08-25T21:55:44.519Z vite:resolve 0.27ms ./ReportBuilder -> /workspace/Synapse/src/components/analytics/ReportBuilder.tsx
+2025-08-25T21:55:44.521Z vite:resolve 0.20ms ./WorkflowAnalytics -> /workspace/Synapse/src/components/analytics/WorkflowAnalytics.tsx
+2025-08-25T21:55:44.521Z vite:resolve 0.26ms /workspace/Synapse/src/components/ui/scroll-area -> /workspace/Synapse/src/components/ui/scroll-area.tsx
+2025-08-25T21:55:44.521Z vite:resolve 0.38ms @/components/ui/scroll-area -> /workspace/Synapse/src/components/ui/scroll-area.tsx
+2025-08-25T21:55:44.524Z vite:resolve 0.35ms /workspace/Synapse/src/hooks/use-collaboration -> /workspace/Synapse/src/hooks/use-collaboration.ts
+2025-08-25T21:55:44.524Z vite:resolve 0.80ms @/hooks/use-collaboration -> /workspace/Synapse/src/hooks/use-collaboration.ts
+2025-08-25T21:55:44.526Z vite:resolve 0.96ms @radix-ui/react-select -> /workspace/Synapse/node_modules/@radix-ui/react-select/dist/index.mjs
+2025-08-25T21:55:44.526Z vite:resolve 1.12ms @radix-ui/react-dialog -> /workspace/Synapse/node_modules/@radix-ui/react-dialog/dist/index.mjs
+2025-08-25T21:55:44.527Z vite:resolve 0.56ms @radix-ui/react-progress -> /workspace/Synapse/node_modules/@radix-ui/react-progress/dist/index.mjs
+2025-08-25T21:55:44.528Z vite:resolve 0.39ms /workspace/Synapse/src/components/ui/popover -> /workspace/Synapse/src/components/ui/popover.tsx
+2025-08-25T21:55:44.528Z vite:resolve 0.61ms @/components/ui/popover -> /workspace/Synapse/src/components/ui/popover.tsx
+2025-08-25T21:55:44.529Z vite:resolve 0.26ms /workspace/Synapse/src/hooks/use-notifications -> /workspace/Synapse/src/hooks/use-notifications.ts
+2025-08-25T21:55:44.529Z vite:resolve 0.56ms @/hooks/use-notifications -> /workspace/Synapse/src/hooks/use-notifications.ts
+2025-08-25T21:55:44.536Z vite:resolve 0.55ms @radix-ui/react-scroll-area -> /workspace/Synapse/node_modules/@radix-ui/react-scroll-area/dist/index.mjs
+2025-08-25T21:55:44.537Z vite:resolve 0.68ms @radix-ui/react-popover -> /workspace/Synapse/node_modules/@radix-ui/react-popover/dist/index.mjs
+2025-08-25T21:55:44.539Z vite:resolve 0.12ms /workspace/Synapse/src/components/ui/calendar -> /workspace/Synapse/src/components/ui/calendar.tsx
+2025-08-25T21:55:44.539Z vite:resolve 0.25ms @/components/ui/calendar -> /workspace/Synapse/src/components/ui/calendar.tsx
+2025-08-25T21:55:44.544Z vite:resolve 0.43ms react-day-picker -> /workspace/Synapse/node_modules/react-day-picker/dist/index.esm.js
+2025-08-25T21:55:44.585Z vite:deps Scan completed in 567.85ms: 
+  @radix-ui/react-alert-dialog -> /workspace/Synapse/node_modules/@radix-ui/react-alert-dialog/dist/index.mjs
+  @radix-ui/react-avatar -> /workspace/Synapse/node_modules/@radix-ui/react-avatar/dist/index.mjs
+  @radix-ui/react-checkbox -> /workspace/Synapse/node_modules/@radix-ui/react-checkbox/dist/index.mjs
+  @radix-ui/react-dialog -> /workspace/Synapse/node_modules/@radix-ui/react-dialog/dist/index.mjs
+  @radix-ui/react-dropdown-menu -> /workspace/Synapse/node_modules/@radix-ui/react-dropdown-menu/dist/index.mjs
+  @radix-ui/react-label -> /workspace/Synapse/node_modules/@radix-ui/react-label/dist/index.mjs
+  @radix-ui/react-popover -> /workspace/Synapse/node_modules/@radix-ui/react-popover/dist/index.mjs
+  @radix-ui/react-progress -> /workspace/Synapse/node_modules/@radix-ui/react-progress/dist/index.mjs
+  @radix-ui/react-scroll-area -> /workspace/Synapse/node_modules/@radix-ui/react-scroll-area/dist/index.mjs
+  @radix-ui/react-select -> /workspace/Synapse/node_modules/@radix-ui/react-select/dist/index.mjs
+  @radix-ui/react-separator -> /workspace/Synapse/node_modules/@radix-ui/react-separator/dist/index.mjs
+  @radix-ui/react-slot -> /workspace/Synapse/node_modules/@radix-ui/react-slot/dist/index.mjs
+  @radix-ui/react-switch -> /workspace/Synapse/node_modules/@radix-ui/react-switch/dist/index.mjs
+  @radix-ui/react-tabs -> /workspace/Synapse/node_modules/@radix-ui/react-tabs/dist/index.mjs
+  @radix-ui/react-toast -> /workspace/Synapse/node_modules/@radix-ui/react-toast/dist/index.mjs
+  @radix-ui/react-tooltip -> /workspace/Synapse/node_modules/@radix-ui/react-tooltip/dist/index.mjs
+  @tanstack/react-query -> /workspace/Synapse/node_modules/@tanstack/react-query/build/modern/index.js
+  class-variance-authority -> /workspace/Synapse/node_modules/class-variance-authority/dist/index.mjs
+  clsx -> /workspace/Synapse/node_modules/clsx/dist/clsx.mjs
+  date-fns -> /workspace/Synapse/node_modules/date-fns/index.mjs
+  lucide-react -> /workspace/Synapse/node_modules/lucide-react/dist/esm/lucide-react.js
+  next-themes -> /workspace/Synapse/node_modules/next-themes/dist/index.mjs
+  react -> /workspace/Synapse/node_modules/react/index.js
+  react-day-picker -> /workspace/Synapse/node_modules/react-day-picker/dist/index.esm.js
+  react-dom/client -> /workspace/Synapse/node_modules/react-dom/client.js
+  react-router-dom -> /workspace/Synapse/node_modules/react-router-dom/dist/index.js
+  react/jsx-runtime -> /workspace/Synapse/node_modules/react/jsx-runtime.js
+  recharts -> /workspace/Synapse/node_modules/recharts/es6/index.js
+  sonner -> /workspace/Synapse/node_modules/sonner/dist/index.mjs
+  tailwind-merge -> /workspace/Synapse/node_modules/tailwind-merge/dist/bundle-mjs.mjs
+2025-08-25T21:55:44.588Z vite:deps creating package.json in /workspace/Synapse/node_modules/.vite/deps_temp_c8c41e36
+2025-08-25T21:55:44.648Z vite:resolve 0.38ms react-dom -> /workspace/Synapse/node_modules/react-dom/index.js
+2025-08-25T21:55:44.649Z vite:resolve 0.41ms react -> /workspace/Synapse/node_modules/react/index.js
+2025-08-25T21:55:44.658Z vite:resolve 0.46ms clsx -> /workspace/Synapse/node_modules/clsx/dist/clsx.mjs
+2025-08-25T21:55:44.662Z vite:resolve 0.36ms react/jsx-runtime -> /workspace/Synapse/node_modules/react/jsx-runtime.js
+2025-08-25T21:55:44.662Z vite:resolve 0.46ms @tanstack/query-core -> /workspace/Synapse/node_modules/@tanstack/query-core/build/modern/index.js
+2025-08-25T21:55:44.687Z vite:resolve 1.26ms react -> /workspace/Synapse/node_modules/react/index.js
+2025-08-25T21:55:44.757Z vite:resolve 2.02ms es-toolkit/compat/last -> /workspace/Synapse/node_modules/es-toolkit/compat/last.js
+2025-08-25T21:55:44.757Z vite:resolve 2.12ms decimal.js-light -> /workspace/Synapse/node_modules/decimal.js-light/decimal.mjs
+2025-08-25T21:55:44.772Z vite:resolve 3.62ms es-toolkit/compat/maxBy -> /workspace/Synapse/node_modules/es-toolkit/compat/maxBy.js
+2025-08-25T21:55:44.776Z vite:resolve 7.26ms es-toolkit/compat/get -> /workspace/Synapse/node_modules/es-toolkit/compat/get.js
+2025-08-25T21:55:44.776Z vite:resolve 6.95ms react-dom -> /workspace/Synapse/node_modules/react-dom/index.js
+2025-08-25T21:55:44.776Z vite:resolve 6.94ms es-toolkit/compat/omit -> /workspace/Synapse/node_modules/es-toolkit/compat/omit.js
+2025-08-25T21:55:44.783Z vite:resolve 0.71ms reselect -> /workspace/Synapse/node_modules/reselect/dist/reselect.mjs
+2025-08-25T21:55:44.815Z vite:resolve 9.18ms @radix-ui/primitive -> /workspace/Synapse/node_modules/@radix-ui/primitive/dist/index.mjs
+2025-08-25T21:55:44.815Z vite:resolve 8.50ms @radix-ui/react-context -> /workspace/Synapse/node_modules/@radix-ui/react-context/dist/index.mjs
+2025-08-25T21:55:44.815Z vite:resolve 7.40ms @radix-ui/react-primitive -> /workspace/Synapse/node_modules/@radix-ui/react-primitive/dist/index.mjs
+2025-08-25T21:55:44.815Z vite:resolve 7.15ms es-toolkit/compat/sortBy -> /workspace/Synapse/node_modules/es-toolkit/compat/sortBy.js
+2025-08-25T21:55:44.815Z vite:resolve 6.85ms @radix-ui/react-compose-refs -> /workspace/Synapse/node_modules/@radix-ui/react-compose-refs/dist/index.mjs
+2025-08-25T21:55:44.815Z vite:resolve 5.21ms es-toolkit/compat/sumBy -> /workspace/Synapse/node_modules/es-toolkit/compat/sumBy.js
+2025-08-25T21:55:44.824Z vite:resolve 3.86ms victory-vendor/d3-scale -> /workspace/Synapse/node_modules/victory-vendor/es/d3-scale.js
+2025-08-25T21:55:44.824Z vite:resolve 3.90ms @radix-ui/number -> /workspace/Synapse/node_modules/@radix-ui/number/dist/index.mjs
+2025-08-25T21:55:44.824Z vite:resolve 3.87ms @reduxjs/toolkit -> /workspace/Synapse/node_modules/@reduxjs/toolkit/dist/redux-toolkit.modern.mjs
+2025-08-25T21:55:44.831Z vite:resolve 4.59ms victory-vendor/d3-shape -> /workspace/Synapse/node_modules/victory-vendor/es/d3-shape.js
+2025-08-25T21:55:44.831Z vite:resolve 4.50ms date-fns -> /workspace/Synapse/node_modules/date-fns/index.mjs
+2025-08-25T21:55:44.869Z vite:resolve 1.19ms @radix-ui/react-use-callback-ref -> /workspace/Synapse/node_modules/@radix-ui/react-use-callback-ref/dist/index.mjs
+2025-08-25T21:55:44.869Z vite:resolve 1.18ms react-router -> /workspace/Synapse/node_modules/react-router/dist/index.js
+2025-08-25T21:55:44.872Z vite:resolve 2.12ms @radix-ui/react-presence -> /workspace/Synapse/node_modules/@radix-ui/react-presence/dist/index.mjs
+2025-08-25T21:55:44.880Z vite:resolve 9.98ms es-toolkit/compat/throttle -> /workspace/Synapse/node_modules/es-toolkit/compat/throttle.js
+2025-08-25T21:55:44.884Z vite:resolve 1.01ms es-toolkit -> /workspace/Synapse/node_modules/es-toolkit/dist/index.mjs
+2025-08-25T21:55:44.884Z vite:resolve 0.95ms es-toolkit/compat/uniqBy -> /workspace/Synapse/node_modules/es-toolkit/compat/uniqBy.js
+2025-08-25T21:55:44.889Z vite:resolve 0.22ms es-toolkit/compat/range -> /workspace/Synapse/node_modules/es-toolkit/compat/range.js
+2025-08-25T21:55:44.898Z vite:resolve 1.17ms @radix-ui/react-roving-focus -> /workspace/Synapse/node_modules/@radix-ui/react-roving-focus/dist/index.mjs
+2025-08-25T21:55:44.899Z vite:resolve 1.20ms @radix-ui/react-dialog -> /workspace/Synapse/node_modules/@radix-ui/react-dialog/dist/index.mjs
+2025-08-25T21:55:44.899Z vite:resolve 1.21ms es-toolkit/compat/minBy -> /workspace/Synapse/node_modules/es-toolkit/compat/minBy.js
+2025-08-25T21:55:44.906Z vite:resolve 1.54ms date-fns/locale -> /workspace/Synapse/node_modules/date-fns/locale.mjs
+2025-08-25T21:55:44.906Z vite:resolve 1.53ms @radix-ui/react-use-layout-effect -> /workspace/Synapse/node_modules/@radix-ui/react-use-layout-effect/dist/index.mjs
+2025-08-25T21:55:44.906Z vite:resolve 1.51ms @remix-run/router -> /workspace/Synapse/node_modules/@remix-run/router/dist/router.js
+2025-08-25T21:55:44.994Z vite:resolve 18.88ms @radix-ui/react-use-controllable-state -> /workspace/Synapse/node_modules/@radix-ui/react-use-controllable-state/dist/index.mjs
+2025-08-25T21:55:44.994Z vite:resolve 18.76ms use-sync-external-store/shim/with-selector -> /workspace/Synapse/node_modules/use-sync-external-store/shim/with-selector.js
+2025-08-25T21:55:44.994Z vite:resolve 17.51ms react-is -> /workspace/Synapse/node_modules/react-is/index.js
+2025-08-25T21:55:44.994Z vite:resolve 17.07ms immer -> /workspace/Synapse/node_modules/immer/dist/immer.mjs
+2025-08-25T21:55:44.994Z vite:resolve 16.98ms @radix-ui/react-collection -> /workspace/Synapse/node_modules/@radix-ui/react-collection/dist/index.mjs
+2025-08-25T21:55:44.994Z vite:resolve 16.65ms @radix-ui/react-dismissable-layer -> /workspace/Synapse/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs
+2025-08-25T21:55:44.994Z vite:resolve 16.01ms redux -> /workspace/Synapse/node_modules/redux/dist/redux.mjs
+2025-08-25T21:55:44.994Z vite:resolve 15.37ms eventemitter3 -> /workspace/Synapse/node_modules/eventemitter3/index.mjs
+2025-08-25T21:55:44.994Z vite:resolve 15.35ms d3-scale -> /workspace/Synapse/node_modules/d3-scale/src/index.js
+2025-08-25T21:55:44.994Z vite:resolve 15.11ms @radix-ui/react-id -> /workspace/Synapse/node_modules/@radix-ui/react-id/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.96ms @radix-ui/react-slot -> /workspace/Synapse/node_modules/@radix-ui/react-slot/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.87ms @radix-ui/react-use-previous -> /workspace/Synapse/node_modules/@radix-ui/react-use-previous/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.88ms @radix-ui/react-use-is-hydrated -> /workspace/Synapse/node_modules/@radix-ui/react-use-is-hydrated/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.89ms scheduler -> /workspace/Synapse/node_modules/scheduler/index.js
+2025-08-25T21:55:45.119Z vite:resolve 2.89ms react-redux -> /workspace/Synapse/node_modules/react-redux/dist/react-redux.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.90ms es-toolkit/compat/isPlainObject -> /workspace/Synapse/node_modules/es-toolkit/compat/isPlainObject.js
+2025-08-25T21:55:45.119Z vite:resolve 2.90ms tiny-invariant -> /workspace/Synapse/node_modules/tiny-invariant/dist/esm/tiny-invariant.js
+2025-08-25T21:55:45.119Z vite:resolve 2.94ms @radix-ui/react-menu -> /workspace/Synapse/node_modules/@radix-ui/react-menu/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.95ms es-toolkit/compat/isEqual -> /workspace/Synapse/node_modules/es-toolkit/compat/isEqual.js
+2025-08-25T21:55:45.119Z vite:resolve 2.92ms @radix-ui/react-direction -> /workspace/Synapse/node_modules/@radix-ui/react-direction/dist/index.mjs
+2025-08-25T21:55:45.119Z vite:resolve 2.92ms @radix-ui/react-focus-guards -> /workspace/Synapse/node_modules/@radix-ui/react-focus-guards/dist/index.mjs
+2025-08-25T21:55:45.150Z vite:resolve 0.41ms d3-array -> /workspace/Synapse/node_modules/d3-array/src/index.js
+2025-08-25T21:55:45.154Z vite:resolve 0.46ms d3-shape -> /workspace/Synapse/node_modules/d3-shape/src/index.js
+2025-08-25T21:55:45.160Z vite:resolve 0.31ms d3-time -> /workspace/Synapse/node_modules/d3-time/src/index.js
+2025-08-25T21:55:45.162Z vite:resolve 0.23ms d3-interpolate -> /workspace/Synapse/node_modules/d3-interpolate/src/index.js
+2025-08-25T21:55:45.168Z vite:resolve 0.37ms @radix-ui/react-popper -> /workspace/Synapse/node_modules/@radix-ui/react-popper/dist/index.mjs
+2025-08-25T21:55:45.171Z vite:resolve 0.24ms @radix-ui/react-use-size -> /workspace/Synapse/node_modules/@radix-ui/react-use-size/dist/index.mjs
+2025-08-25T21:55:45.186Z vite:resolve 1.65ms @radix-ui/react-focus-scope -> /workspace/Synapse/node_modules/@radix-ui/react-focus-scope/dist/index.mjs
+2025-08-25T21:55:45.186Z vite:resolve 1.76ms d3-format -> /workspace/Synapse/node_modules/d3-format/src/index.js
+2025-08-25T21:55:45.186Z vite:resolve 1.77ms use-sync-external-store/shim -> /workspace/Synapse/node_modules/use-sync-external-store/shim/index.js
+2025-08-25T21:55:45.186Z vite:resolve 1.77ms d3-time-format -> /workspace/Synapse/node_modules/d3-time-format/src/index.js
+2025-08-25T21:55:45.186Z vite:resolve 1.73ms d3-color -> /workspace/Synapse/node_modules/d3-color/src/index.js
+2025-08-25T21:55:45.186Z vite:resolve 1.73ms internmap -> /workspace/Synapse/node_modules/internmap/src/index.js
+2025-08-25T21:55:45.196Z vite:resolve 0.40ms d3-path -> /workspace/Synapse/node_modules/d3-path/src/index.js
+2025-08-25T21:55:45.209Z vite:resolve 4.27ms @radix-ui/react-portal -> /workspace/Synapse/node_modules/@radix-ui/react-portal/dist/index.mjs
+2025-08-25T21:55:45.209Z vite:resolve 4.33ms redux-thunk -> /workspace/Synapse/node_modules/redux-thunk/dist/redux-thunk.mjs
+2025-08-25T21:55:45.209Z vite:resolve 4.30ms use-sync-external-store/with-selector.js -> /workspace/Synapse/node_modules/use-sync-external-store/with-selector.js
+2025-08-25T21:55:45.209Z vite:resolve 4.24ms use-sync-external-store/shim -> /workspace/Synapse/node_modules/use-sync-external-store/shim/index.js
+2025-08-25T21:55:45.234Z vite:resolve 0.46ms @radix-ui/react-use-effect-event -> /workspace/Synapse/node_modules/@radix-ui/react-use-effect-event/dist/index.mjs
+2025-08-25T21:55:45.241Z vite:resolve 0.45ms @radix-ui/react-visually-hidden -> /workspace/Synapse/node_modules/@radix-ui/react-visually-hidden/dist/index.mjs
+2025-08-25T21:55:45.315Z vite:resolve 1.17ms react-remove-scroll -> /workspace/Synapse/node_modules/react-remove-scroll/dist/es2015/index.js
+2025-08-25T21:55:45.457Z vite:resolve 2.20ms aria-hidden -> /workspace/Synapse/node_modules/aria-hidden/dist/es2015/index.js
+2025-08-25T21:55:45.768Z vite:resolve 0.51ms @floating-ui/react-dom -> /workspace/Synapse/node_modules/@floating-ui/react-dom/dist/floating-ui.react-dom.mjs
+2025-08-25T21:55:45.781Z vite:resolve 0.39ms @radix-ui/react-arrow -> /workspace/Synapse/node_modules/@radix-ui/react-arrow/dist/index.mjs
+2025-08-25T21:55:45.802Z vite:resolve 6.50ms tslib -> /workspace/Synapse/node_modules/tslib/tslib.es6.mjs
+2025-08-25T21:55:45.802Z vite:resolve 1.48ms @radix-ui/react-use-escape-keydown -> /workspace/Synapse/node_modules/@radix-ui/react-use-escape-keydown/dist/index.mjs
+2025-08-25T21:55:45.805Z vite:resolve 0.65ms use-sidecar -> /workspace/Synapse/node_modules/use-sidecar/dist/es2015/index.js
+2025-08-25T21:55:45.823Z vite:resolve 1.11ms detect-node-es -> /workspace/Synapse/node_modules/detect-node-es/esm/browser.js
+2025-08-25T21:55:45.827Z vite:resolve 0.76ms react-remove-scroll-bar/constants -> /workspace/Synapse/node_modules/react-remove-scroll-bar/dist/es2015/constants.js
+2025-08-25T21:55:45.828Z vite:resolve 0.37ms react-remove-scroll-bar -> /workspace/Synapse/node_modules/react-remove-scroll-bar/dist/es2015/index.js
+2025-08-25T21:55:45.834Z vite:resolve 1.36ms use-callback-ref -> /workspace/Synapse/node_modules/use-callback-ref/dist/es2015/index.js
+2025-08-25T21:55:45.834Z vite:resolve 1.34ms @floating-ui/dom -> /workspace/Synapse/node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs
+2025-08-25T21:55:45.834Z vite:resolve 1.29ms react-style-singleton -> /workspace/Synapse/node_modules/react-style-singleton/dist/es2015/index.js
+2025-08-25T21:55:45.841Z vite:resolve 0.43ms get-nonce -> /workspace/Synapse/node_modules/get-nonce/dist/es2015/index.js
+2025-08-25T21:55:45.844Z vite:resolve 0.54ms @floating-ui/core -> /workspace/Synapse/node_modules/@floating-ui/core/dist/floating-ui.core.mjs
+2025-08-25T21:55:45.845Z vite:resolve 0.39ms @floating-ui/utils -> /workspace/Synapse/node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs
+2025-08-25T21:55:45.846Z vite:resolve 0.16ms @floating-ui/utils/dom -> /workspace/Synapse/node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs
+2025-08-25T21:55:46.561Z vite:deps Dependencies bundled in 1968.64ms
+2025-08-25T21:56:03.400Z vite:deps removing cache dir /workspace/Synapse/node_modules/.vite/deps_temp_c8c41e36
+```

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,6 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": [
-    "a30a6eba6312f6b87ea5-21eb2015a8165a61d6ae"
-  ]
-}

--- a/tests/e2e/actions.e2e.ts
+++ b/tests/e2e/actions.e2e.ts
@@ -17,8 +17,10 @@ test.describe('actions', () => {
   for (const { path, id } of actions) {
     test(`click ${id}`, async ({ page }, testInfo) => {
       await page.goto(base + path);
-      const btn = page.getByTestId(id);
-      if (await btn.count() === 0) test.skip();
+      const btns = page.getByTestId(id);
+      const count = await btns.count();
+      if (count === 0) test.skip();
+      const btn = count > 1 ? btns.first() : btns;
 
       const errors: string[] = [];
       page.on('pageerror', (err) => errors.push(String(err)));

--- a/tests/e2e/buttons-audit.e2e.ts
+++ b/tests/e2e/buttons-audit.e2e.ts
@@ -1,0 +1,144 @@
+import { test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const FALLBACK_ROUTES = ['/', '/documents', '/meetings', '/proposals', '/knowledge', '/workflows', '/analytics', '/collaboration', '/security', '/settings'];
+
+function getPort(): number {
+  try {
+    const vite = fs.readFileSync('vite.config.ts', 'utf-8');
+    const m = vite.match(/port:\s*(\d+)/);
+    return m ? parseInt(m[1], 10) : 5173;
+  } catch {
+    return 5173;
+  }
+}
+
+function getRoutes(): string[] {
+  try {
+    const app = fs.readFileSync('src/App.tsx', 'utf-8');
+    const matches = Array.from(app.matchAll(/<Route path="([^"]+)"/g)).map(m => m[1]);
+    const filtered = matches.filter(p => p !== '*' && p.startsWith('/'));
+    return Array.from(new Set([...filtered, ...FALLBACK_ROUTES]));
+  } catch {
+    return FALLBACK_ROUTES;
+  }
+}
+
+const PORT = getPort();
+const BASE = process.env.PW_BASE_URL || `http://localhost:${PORT}`;
+const ROUTES = getRoutes();
+
+const ARTIFACT = 'artifacts/buttons-audit.json';
+
+async function appendResults(results: any[]) {
+  await fs.promises.mkdir(path.dirname(ARTIFACT), { recursive: true });
+  const existing = fs.existsSync(ARTIFACT) ? JSON.parse(fs.readFileSync(ARTIFACT, 'utf-8')) : [];
+  existing.push(...results);
+  fs.writeFileSync(ARTIFACT, JSON.stringify(existing, null, 2));
+}
+
+test.describe.serial('buttons audit', () => {
+  for (const route of ROUTES) {
+    test(`route ${route}`, async ({ page }, testInfo) => {
+      await page.goto(BASE + route);
+      await page.waitForSelector('#root', { state: 'visible' });
+
+      const errors: string[] = [];
+      page.on('pageerror', e => errors.push(`pageerror: ${e.message}`));
+      page.on('console', m => { if (m.type() === 'error') errors.push(`console: ${m.text()}`); });
+      const requests: string[] = [];
+      page.on('request', r => requests.push(`${r.method()} ${r.url()}`));
+
+      const candidateSelector = [
+        'button',
+        '[role="button"]',
+        '[type="button"]',
+        'a[role="button"]',
+        '[data-testid$="-btn"]',
+        '[data-action]'
+      ].join(',');
+
+      const candidates = page.locator(candidateSelector);
+      const total = await candidates.count();
+      const limit = Math.min(total, 15);
+      const results: any[] = [];
+
+      for (let i = 0, seen = 0; seen < limit && i < total; i++) {
+        const el = candidates.nth(i);
+        if (!(await el.isVisible()) || (await el.isDisabled?.()) === true) continue;
+        const text = (await el.innerText()).trim();
+        const testid = await el.getAttribute('data-testid');
+        const lower = `${text} ${testid || ''}`.toLowerCase();
+        if (/delete|remove|apagar|eliminar|danger|desvincular/.test(lower)) continue;
+        seen++;
+
+        const selector = await el.evaluate(node => {
+          const tag = node.tagName.toLowerCase();
+          const id = node.id ? `#${node.id}` : '';
+          const cls = node.className ? '.' + node.className.toString().split(/\s+/).join('.') : '';
+          return tag + id + cls;
+        });
+        const bbox = await el.boundingBox();
+        const before = await el.evaluate(node => ({
+          className: node.className,
+          ariaPressed: node.getAttribute('aria-pressed'),
+          hidden: (node as any).hidden
+        }));
+        const urlBefore = page.url();
+        errors.length = 0;
+        requests.length = 0;
+        let clickErr: string | undefined;
+        try {
+          await el.click({ trial: false, timeout: 1000 });
+        } catch (e: any) {
+          clickErr = e.message;
+        }
+        await page.waitForTimeout(800);
+        const urlAfter = page.url();
+        const dialog = await page.$('role=dialog');
+        const domAfter = await el.evaluate(node => node ? ({
+          className: node.className,
+          ariaPressed: node.getAttribute('aria-pressed'),
+          hidden: (node as any).hidden
+        }) : null);
+        const domChanged = !domAfter || before.className !== domAfter.className || before.ariaPressed !== domAfter.ariaPressed || before.hidden !== domAfter.hidden;
+        let status: 'OK' | 'Broken' | 'Suspicious' = 'Suspicious';
+        const reasons: string[] = [];
+        if (errors.length || clickErr) {
+          status = 'Broken';
+          if (clickErr) reasons.push(`click: ${clickErr}`);
+          reasons.push(...errors);
+        } else if (urlBefore !== urlAfter) {
+          status = 'OK';
+          reasons.push('url changed');
+        } else if (dialog) {
+          status = 'OK';
+          reasons.push('dialog appeared');
+        } else if (domChanged) {
+          status = 'OK';
+          reasons.push('dom changed');
+        } else if (requests.length) {
+          status = 'OK';
+          reasons.push('network request');
+        } else {
+          reasons.push('no url change/dialog/dom/network');
+        }
+
+        let screenshotPath: string | undefined;
+        if (status !== 'OK') {
+          const safeText = (text || 'button').replace(/[^a-z0-9]+/gi, '_').slice(0, 50);
+          const routeSlug = route === '/' ? 'root' : route.replace(/\//g, '_');
+          const dir = path.join('test-results', 'buttons-audit', routeSlug);
+          await fs.promises.mkdir(dir, { recursive: true });
+          screenshotPath = path.join(dir, `${safeText}.png`);
+          await page.screenshot({ path: screenshotPath });
+        }
+
+        results.push({ route, selector, text, testid, status, reasons, urlBefore, urlAfter, requests: [...requests], screenshotPath, bbox });
+      }
+
+      await appendResults(results);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright audit for buttons across top-level routes
- capture dev server diagnostics and produce buttons-audit report
- drop committed screenshots and stabilize existing action tests

## Testing
- `npm run lint`
- `PW_BASE_URL=http://localhost:5173 npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68acdb25785c832dbb091dd968207815